### PR TITLE
add rotation for joints

### DIFF
--- a/crates/nora_physics/src/collider.rs
+++ b/crates/nora_physics/src/collider.rs
@@ -52,8 +52,8 @@ impl Default for ColliderPhysicalProperties {
     fn default() -> Self {
         Self {
             density: 1.0,
-            friction: 0.7,
-            restitution: 0.3
+            friction: 0.9,
+            restitution: 0.0
         }
     }
 }


### PR DESCRIPTION
Revolute joints does not seem to have an api for
setting the local frame which prevents rotation of the joint.
A way around this without change the rapier source is to set the
local frames on the GenericJoint directly.

Also added a car model to test the joints and to highlight flaws
in the spawning api.

also increased the default friciton and set default restitution to zero