### PR TITLE
add simple spider model to playground example

### DIFF
--- a/crates/nora_physics/src/conversions.rs
+++ b/crates/nora_physics/src/conversions.rs
@@ -1,4 +1,5 @@
 use bevy::math::{Vec3, Quat};
+use bevy::prelude::Transform;
 use rapier3d::math::{Translation, Isometry, Vector};
 use nalgebra::{UnitQuaternion, Vector3, Quaternion, Point3, UnitVector3};
 
@@ -71,5 +72,11 @@ impl IntoRapier<UnitQuaternion<f32>> for Quat {
 impl IntoRapier<Isometry<f32>> for (Vec3, Quat) {
     fn into_rapier(self) -> Isometry<f32> {
         Isometry::from_parts(self.0.into_rapier(), self.1.into_rapier())
+    }
+}
+
+impl IntoRapier<Isometry<f32>> for Transform {
+    fn into_rapier(self) -> Isometry<f32> {
+        Isometry::from_parts(self.translation.into_rapier(), self.rotation.into_rapier())
     }
 }

--- a/crates/nora_physics/src/joint.rs
+++ b/crates/nora_physics/src/joint.rs
@@ -14,8 +14,8 @@ pub(crate) struct JointHandle(pub(crate) rapier::ImpulseJointHandle);
 pub struct Joint {
     pub joint_type: JointType,
     pub parent: Entity,
-    pub parent_anchor: (Vec3, Quat),
-    pub child_anchor: (Vec3, Quat)
+    pub parent_anchor: Transform,
+    pub child_anchor: Transform
 }
 
 /// Represents a specific joint type and its parameters
@@ -93,14 +93,16 @@ mod tests {
     use crate::rigid_body::{EntityBodyHandleMap, RigidBodyHandle};
     use super::add_joints_system;
 
-    const ANCHOR_PARENT: (Vec3, Quat) = (Vec3::X, Quat::IDENTITY);
-    const ANCHOR_CHILD: (Vec3, Quat) = (Vec3::X, Quat::IDENTITY);
-
     struct TestCtx {
         child_entity: Entity,
         parent_body_handle: rapier::RigidBodyHandle,
         child_body_handle: rapier::RigidBodyHandle
     }
+
+    fn get_expected_transform() -> Transform {
+        Transform::from_translation(Vec3::X)
+    }
+
 
     fn setup(world: &mut World, joint_type: JointType) -> TestCtx {
 
@@ -115,8 +117,8 @@ mod tests {
         let joint = Joint {
             joint_type,
             parent: parent_entity,
-            parent_anchor: ANCHOR_PARENT,
-            child_anchor: ANCHOR_CHILD
+            parent_anchor: get_expected_transform(),
+            child_anchor: get_expected_transform()
         };
 
         let child_body_handle = rapier::RigidBodyHandle::from_raw_parts(2, 0);
@@ -169,8 +171,8 @@ mod tests {
         assert_eq!(joint.body2, ctx.child_body_handle);
 
         assert!(joint.data.as_fixed().is_some());
-        assert_eq!(joint.data.local_frame1, ANCHOR_PARENT.into_rapier());
-        assert_eq!(joint.data.local_frame2, ANCHOR_CHILD.into_rapier());
+        assert_eq!(joint.data.local_frame1, get_expected_transform().into_rapier());
+        assert_eq!(joint.data.local_frame2, get_expected_transform().into_rapier());
     }
 
     #[test]
@@ -195,8 +197,8 @@ mod tests {
         assert_eq!(joint.body2, ctx.child_body_handle);
 
         assert!(joint.data.as_spherical().is_some());
-        assert_eq!(joint.data.local_frame1, ANCHOR_PARENT.into_rapier());
-        assert_eq!(joint.data.local_frame2, ANCHOR_CHILD.into_rapier());
+        assert_eq!(joint.data.local_frame1, get_expected_transform().into_rapier());
+        assert_eq!(joint.data.local_frame2, get_expected_transform().into_rapier());
     }
 
     #[test]
@@ -231,8 +233,8 @@ mod tests {
         assert_eq!(joint.data.local_axis2(), Vec3::X.into_rapier());
 
         // anchor points
-        assert_eq!(joint.data.local_frame1, ANCHOR_PARENT.into_rapier());
-        assert_eq!(joint.data.local_frame2, ANCHOR_CHILD.into_rapier());
+        assert_eq!(joint.data.local_frame1, get_expected_transform().into_rapier());
+        assert_eq!(joint.data.local_frame2, get_expected_transform().into_rapier());
     }
 
     #[test]
@@ -273,7 +275,7 @@ mod tests {
         assert_eq!(joint.data.limits(JointAxis::X).unwrap().min, -2.0);
 
         // anchor points
-        assert_eq!(joint.data.local_frame1, ANCHOR_PARENT.into_rapier());
-        assert_eq!(joint.data.local_frame2, ANCHOR_CHILD.into_rapier());
+        assert_eq!(joint.data.local_frame1, get_expected_transform().into_rapier());
+        assert_eq!(joint.data.local_frame2, get_expected_transform().into_rapier());
     }
 }

--- a/examples/playground.rs
+++ b/examples/playground.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::FRAC_PI_2;
+use std::f32::consts::{FRAC_PI_2, FRAC_PI_4};
 
 use bevy::prelude::*;
 use bevy::diagnostic::{LogDiagnosticsPlugin, FrameTimeDiagnosticsPlugin};
@@ -29,6 +29,7 @@ fn main() {
         .add_plugin(FPSScreenPlugin::default())
         .add_startup_system(setup)
         .add_startup_system(spawn_car)
+        .add_startup_system(spawn_spider)
         .add_system(bevy::input::system::exit_on_esc_system)
         .insert_resource(ClearColor(Color::hex("F5F5F5").unwrap()))
         .run();
@@ -82,8 +83,8 @@ fn setup(
             .insert(Joint {
                 joint_type: JointType::Spherical,
                 parent: root,
-                parent_anchor: (Vec3::new(0.0, 0.25, 0.0), Quat::default()),
-                child_anchor: (Vec3::new(0.0, -0.25, 0.0), Quat::default()),
+                parent_anchor: Transform::from_translation(Vec3::new(0.0, 0.25, 0.0)),
+                child_anchor: Transform::from_translation(Vec3::new(0.0, -0.25, 0.0)),
             })
             .insert_bundle(InteractiveBundle::default())
             .id();
@@ -207,8 +208,8 @@ fn spawn_car(
         .insert(Joint {
             joint_type: JointType::Fixed,
             parent: frame,
-            parent_anchor: (Vec3::new(0.0, frame_height / 2.0, flh - 0.05), Quat::default()),
-            child_anchor: (Vec3::new(0.0, -0.1, 0.0), Quat::default()),
+            parent_anchor: Transform::from_translation(Vec3::new(0.0, frame_height / 2.0, flh - 0.05)),
+            child_anchor: Transform::from_translation(Vec3::new(0.0, -0.1, 0.0)),
         })
         .insert_bundle(InteractiveBundle::default());
 
@@ -223,8 +224,8 @@ fn spawn_car(
         .insert(Joint {
             joint_type: JointType::Fixed,
             parent: frame,
-            parent_anchor: (Vec3::new(0.0, frame_height / 2.0, 0.05 - flh), Quat::default()),
-            child_anchor: (Vec3::new(0.0, -0.1, 0.0), Quat::default()),
+            parent_anchor: Transform::from_translation(Vec3::new(0.0, frame_height / 2.0, 0.05 - flh)),
+            child_anchor: Transform::from_translation(Vec3::new(0.0, -0.1, 0.0)),
         })
         .insert_bundle(InteractiveBundle::default());
 
@@ -239,8 +240,8 @@ fn spawn_car(
         .insert(Joint {
             joint_type: JointType::Fixed,
             parent: frame,
-            parent_anchor: (Vec3::new(-frame_width / 2.0 + 0.05, frame_height / 2.0, 0.0), Quat::default()),
-            child_anchor: (Vec3::new(0.0, -0.1, 0.0), Quat::default()),
+            parent_anchor: Transform::from_translation(Vec3::new(-frame_width / 2.0 + 0.05, frame_height / 2.0, 0.0)),
+            child_anchor: Transform::from_translation(Vec3::new(0.0, -0.1, 0.0)),
         })
         .insert_bundle(InteractiveBundle::default());
 
@@ -255,8 +256,8 @@ fn spawn_car(
         .insert(Joint {
             joint_type: JointType::Fixed,
             parent: frame,
-            parent_anchor: (Vec3::new(frame_width / 2.0 - 0.05, frame_height / 2.0, 0.0), Quat::default()),
-            child_anchor: (Vec3::new(0.0, -0.1, 0.0), Quat::default()),
+            parent_anchor: Transform::from_translation(Vec3::new(frame_width / 2.0 - 0.05, frame_height / 2.0, 0.0)),
+            child_anchor: Transform::from_translation(Vec3::new(0.0, -0.1, 0.0)),
         })
         .insert_bundle(InteractiveBundle::default());
 
@@ -271,8 +272,8 @@ fn spawn_car(
         .insert(Joint {
             joint_type: JointType::Revolute {axis: Vec3::Y},
             parent: frame,
-            parent_anchor: (Vec3::new(wbh, 0.0, flh), Quat::default()),
-            child_anchor: (Vec3::ZERO, Quat::from_rotation_z(FRAC_PI_2)),
+            parent_anchor: Transform::from_translation(Vec3::new(wbh, 0.0, flh)),
+            child_anchor: Transform::from_rotation(Quat::from_rotation_z(FRAC_PI_2)),
         });
 
     // right front wheel
@@ -286,8 +287,8 @@ fn spawn_car(
         .insert(Joint {
             joint_type: JointType::Revolute {axis: Vec3::Y},
             parent: frame,
-            parent_anchor: (Vec3::new(-wbh, 0.0, flh), Quat::default()),
-            child_anchor: (Vec3::new(0.0, 0.0, 0.0), Quat::from_rotation_z(FRAC_PI_2)),
+            parent_anchor: Transform::from_translation(Vec3::new(-wbh, 0.0, flh)),
+            child_anchor: Transform::from_rotation(Quat::from_rotation_z(FRAC_PI_2)),
         });
 
     // left back wheel
@@ -301,8 +302,8 @@ fn spawn_car(
         .insert(Joint {
             joint_type: JointType::Revolute {axis: Vec3::Y},
             parent: frame,
-            parent_anchor: (Vec3::new(wbh, 0.0, -flh), Quat::default()),
-            child_anchor: (Vec3::new(0.0, 0.0, 0.0), Quat::from_rotation_z(FRAC_PI_2)),
+            parent_anchor: Transform::from_translation(Vec3::new(wbh, 0.0, -flh)),
+            child_anchor: Transform::from_rotation(Quat::from_rotation_z(FRAC_PI_2)),
         });
 
     // right back wheel
@@ -316,8 +317,102 @@ fn spawn_car(
         .insert(Joint {
             joint_type: JointType::Revolute {axis: Vec3::Y},
             parent: frame,
-            parent_anchor: (Vec3::new(-wbh, 0.0, -flh), Quat::default()),
-            child_anchor: (Vec3::new(0.0, 0.0, 0.0), Quat::from_rotation_z(FRAC_PI_2)),
+            parent_anchor: Transform::from_translation(Vec3::new(-wbh, 0.0, -flh)),
+            child_anchor: Transform::from_rotation(Quat::from_rotation_z(FRAC_PI_2)),
         });
+}
 
+
+fn spawn_spider(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>
+) {
+    let body_radius = 0.2;
+    let arm_length = 0.3;
+    let arm_radius = 0.06;
+    let alh = arm_length / 2.0;
+    let gap = 0.01;
+
+    let origin = Transform::from_xyz(0.0, 2.0, 2.0);
+
+    // Frame
+    let body = commands.spawn_bundle(PhysicBodyBundle::from(
+        RigidBody::Dynamic,
+        Shape::Sphere { radius: body_radius, subdivisions: 7 },
+        materials.add(Color::ORANGE_RED.into()),
+        origin,
+        &mut meshes
+    ))
+        .insert_bundle(InteractiveBundle::default())
+        .id();
+
+    // left_front_leg
+    commands.spawn_bundle(PhysicBodyBundle::from(
+        RigidBody::Dynamic,
+        Shape::Capsule { radius: arm_radius, length: arm_length },
+        materials.add(Color::ORANGE_RED.into()),
+        Transform::from_rotation(Quat::from_axis_angle(Vec3::new(-1.0, 0.0, 1.0), -FRAC_PI_4))
+            .with_translation(Vec3::new(1.0, 0.0, 1.0).normalize() + body_radius + alh + arm_radius + gap),
+        &mut meshes
+    ))
+        .insert(Joint {
+            joint_type: JointType::Fixed,
+            parent: body,
+            parent_anchor: Transform::from_translation(body_radius * Vec3::new(1.0, 0.0, 1.0).normalize()),
+            child_anchor: Transform::from_translation(Vec3::new(0.0, alh + arm_radius + gap, 0.0))
+                .with_rotation(Quat::from_axis_angle(Vec3::new(-1.0, 0.0, 1.0), -FRAC_PI_4)),
+        })
+        .insert_bundle(InteractiveBundle::default());
+
+    // right_front_leg
+    commands.spawn_bundle(PhysicBodyBundle::from(
+        RigidBody::Dynamic,
+        Shape::Capsule { radius: arm_radius, length: arm_length },
+        materials.add(Color::ORANGE_RED.into()),
+        Transform::from_rotation(Quat::from_axis_angle(Vec3::new(1.0, 0.0, 1.0), FRAC_PI_4))
+            .with_translation(Vec3::new(-1.0, 0.0, 1.0).normalize() * (body_radius + alh + arm_radius + gap)),
+        &mut meshes
+    ))
+        .insert(Joint {
+            joint_type: JointType::Fixed,
+            parent: body,
+            parent_anchor: Transform::from_translation(body_radius * Vec3::new(-1.0, 0.0, 1.0).normalize()),
+            child_anchor: Transform::from_translation(Vec3::new(0.0, alh + arm_radius + gap, 0.0)).with_rotation(Quat::from_axis_angle(Vec3::new(1.0, 0.0, 1.0), FRAC_PI_4)),
+        })
+        .insert_bundle(InteractiveBundle::default());
+
+    // right_back_leg
+    commands.spawn_bundle(PhysicBodyBundle::from(
+        RigidBody::Dynamic,
+        Shape::Capsule { radius: arm_radius, length: arm_length },
+        materials.add(Color::ORANGE_RED.into()),
+        Transform::from_rotation(Quat::from_axis_angle(Vec3::new(-1.0, 0.0, 1.0), FRAC_PI_4))
+            .with_translation((body_radius + alh + arm_radius + gap) * Vec3::new(-1.0, 0.0, -1.0).normalize()),
+        &mut meshes
+    ))
+        .insert(Joint {
+            joint_type: JointType::Fixed,
+            parent: body,
+            parent_anchor: Transform::from_translation(body_radius * Vec3::new(-1.0, 0.0, -1.0).normalize()),
+            child_anchor: Transform::from_translation(Vec3::new(0.0, alh + arm_radius + gap, 0.0)).with_rotation(Quat::from_axis_angle(Vec3::new(-1.0, 0.0, 1.0), FRAC_PI_4)),
+        })
+        .insert_bundle(InteractiveBundle::default());
+
+    // left_back_leg
+    commands.spawn_bundle(PhysicBodyBundle::from(
+        RigidBody::Dynamic,
+        Shape::Capsule { radius: arm_radius, length: arm_length },
+        materials.add(Color::ORANGE_RED.into()),
+        Transform::from_rotation(Quat::from_axis_angle(Vec3::new(1.0, 0.0, 1.0), -FRAC_PI_4))
+            .with_translation((body_radius + alh + arm_radius + gap) * Vec3::new(1.0, 0.0, -1.0).normalize()),
+        &mut meshes
+    ))
+        .insert(Joint {
+            joint_type: JointType::Fixed,
+            parent: body,
+            parent_anchor: Transform::from_translation(body_radius * Vec3::new(1.0, 0.0, -1.0).normalize()),
+            child_anchor: Transform::from_translation(Vec3::new(0.0, alh + arm_radius + gap, 0.0)).with_rotation(Quat::from_axis_angle(Vec3::new(1.0, 0.0, 1.0), -FRAC_PI_4)),
+        })
+        .insert_bundle(InteractiveBundle::default());
 }


### PR DESCRIPTION
the model will be used to decide the model building api.
currently it is very inconvenient to construct multibody
entities with a combination of joints and shapes.