### PR TITLE
first iteration and implementation of multibody support

### DIFF
--- a/crates/nora_core/src/diagnostic/event.rs
+++ b/crates/nora_core/src/diagnostic/event.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use nora_object_interaction::event::InteractionEvent;
-use nora_physics::event::CollisionEvent;
+use nora_physics::{event::CollisionEvent, joint::JointMotorEvent};
 
 
 pub struct DebugEventPlugin;
@@ -11,15 +11,18 @@ impl Plugin for DebugEventPlugin {
     }
 }
 
-
 pub fn debug_events(
     mut collision_event_reader: EventReader<CollisionEvent>,
-    mut interaction_event_reader: EventReader<InteractionEvent>
+    mut interaction_event_reader: EventReader<InteractionEvent>,
+    mut joint_event_reader: EventReader<JointMotorEvent>
 ) {
     for interaction_event in interaction_event_reader.iter() {
         info!("Interaction event {:?}", interaction_event);
     }
     for collision_event in collision_event_reader.iter() {
         info!("Collision event {:?}", collision_event);
+    }
+    for joint_event in joint_event_reader.iter() {
+        info!("Joint event {:?}", joint_event);
     }
 }

--- a/crates/nora_physics/Cargo.toml
+++ b/crates/nora_physics/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.7.0"
-rapier3d = "0.12.0"
+rapier3d = "0.13.0"
 nalgebra = "0.31.0"
 fnv = "1.0.7"
 crossbeam = "0.8.1"

--- a/crates/nora_physics/src/collider.rs
+++ b/crates/nora_physics/src/collider.rs
@@ -134,12 +134,13 @@ mod tests {
     use bevy::prelude::*;
     use rapier3d::prelude as rapier;
     use crate::collider::{EntityColliderMap, ColliderShape, ColliderPhysicalProperties, add_collider_to_bodies_system, ColliderHandle};
-    use crate::rigid_body::{RigidBody, EntityBodyHandleMap, add_rigid_bodies_system};
+    use crate::rigid_body::{RigidBody, Entity2BodyHandle, add_rigid_bodies_system, BodyHandle2Entity};
 
     fn setup_world() -> (World, SystemStage) {
 
         let mut world = World::default();
-        world.init_resource::<EntityBodyHandleMap>();
+        world.init_resource::<Entity2BodyHandle>();
+        world.init_resource::<BodyHandle2Entity>();
         world.init_resource::<EntityColliderMap>();
 
         world.init_resource::<rapier::RigidBodySet>();
@@ -179,7 +180,7 @@ mod tests {
         assert_eq!(collider_set.len(), 1);
 
         // check that collider has correct parent
-        let body_map = world.get_resource::<EntityBodyHandleMap>().unwrap();
+        let body_map = world.get_resource::<Entity2BodyHandle>().unwrap();
         let body_handle = body_map.get(&entity).unwrap();
         let collider = collider_set.get(*collider_handle).unwrap();
         let parent_body = collider.parent().unwrap();

--- a/crates/nora_physics/src/joint.rs
+++ b/crates/nora_physics/src/joint.rs
@@ -6,7 +6,7 @@ pub mod prismatic;
 use bevy::prelude::*;
 use rapier3d::prelude as rapier;
 use rapier3d::dynamics::GenericJoint;
-use crate::rigid_body::{EntityBodyHandleMap, RigidBodyHandle};
+use crate::rigid_body::{Entity2BodyHandle, RigidBodyHandle};
 
 
 /// Component for connecting two bodies with a joint. This component should be added to the body that wants to connect
@@ -40,7 +40,7 @@ pub(crate) struct MultibodyJointHandle(pub(crate) rapier::MultibodyJointHandle);
 pub(crate) fn add_multibody_joints_system(
     mut commands: Commands,
     mut joint_set: ResMut<rapier::MultibodyJointSet>,
-    entity_body_map: Res<EntityBodyHandleMap>,
+    entity_body_map: Res<Entity2BodyHandle>,
     query: Query<(Entity, &Joint), (With<RigidBodyHandle>, Without<MultibodyJointHandle>)>
 ) {
 
@@ -48,327 +48,343 @@ pub(crate) fn add_multibody_joints_system(
         let joint_handle = joint_set.insert(
             *entity_body_map.get(&joint_comp.parent).unwrap(),
             *entity_body_map.get(&entity).unwrap(),
-            joint_comp.joint
+            joint_comp.joint,
+            true
         ).unwrap();
         commands.entity(entity).insert(MultibodyJointHandle(joint_handle));
     }
 }
 
 /// Event for communicate joint motor positions and velocities
-pub enum JointEvent {
-    SetPositionRevolute {
-        entity: Entity,
+#[derive(Debug)]
+pub struct JointMotorEvent {
+    pub entity: Entity,
+    pub action: MotorAction
+}
+
+#[derive(Debug)]
+pub enum MotorAction {
+    PositionRevolute {
         position: f32,
-        dampning: f32,
+        damping: f32,
         stiffness: f32,
     },
-    SetVelocityRevolute {
-        entity: Entity,
+    VelocityRevolute {
         velocity: f32,
         factor: f32
     },
-    SetPositionSpherical {
-        entity: Entity,
+    PositionSpherical {
         position: f32,
         axis: rapier::JointAxis,
-        dampning: f32,
+        damping: f32,
         stiffness: f32,
     },
-    SetVelocitySpherical {
-        entity: Entity,
+    VelocitySpherical {
         velocity: f32,
         axis: rapier::JointAxis,
         factor: f32
     },
 }
 
-// pub(crate) fn update_joint_motors_system(
-//     mut joint_event: EventReader<JointEvent>,
-//     mut joint_set: ResMut<rapier::ImpulseJointSet>,
-//     mut query: Query<&JointHandle, With<JointHandle>>
-// ) {
+pub(crate) fn update_joint_motors_system(
+    mut joint_event: EventReader<JointMotorEvent>,
+    mut joint_set: ResMut<rapier::MultibodyJointSet>,
+    mut query: Query<&MultibodyJointHandle, With<MultibodyJointHandle>>
+) {
 
-//     for event in joint_event.iter() {
+    for event in joint_event.iter() {
+        match query.get_mut(event.entity) {
+            Err(e) => error!("{:?}", e),
+            Ok(joint_handle) => match joint_set.get_mut(joint_handle.0) {
 
-//         match event {
-//             JointEvent::SetPositionRevolute { entity, position , dampning, stiffness} => {
-//                 if let Ok(handle) = query.get_mut(*entity) {
-//                     if let Some(joint) = joint_set.get_mut(handle.0) {
-//                         if let Some(rev_joint) = joint.data.as_revolute_mut() {
-//                             rev_joint.set_motor_position(*position, *stiffness, *dampning);
-//                         }
-//                     }
-//                 }
-//             },
-//             JointEvent::SetVelocityRevolute{entity, velocity, factor} => {
-//                 if let Ok(handle) = query.get_mut(*entity) {
-//                     if let Some(joint) = joint_set.get_mut(handle.0) {
-//                         if let Some(revolute_joint) = joint.data.as_revolute_mut() {
-//                             revolute_joint.set_motor_velocity(*velocity, *factor);
-//                         }
-//                     }
-//                 }
-//             },
-//             JointEvent::SetPositionSpherical { entity , axis, position, dampning, stiffness} => {
-//                 if let Ok(handle) = query.get_mut(*entity) {
-//                     if let Some(joint) = joint_set.get_mut(handle.0) {
-//                         if let Some(spherical_joint) = joint.data.as_spherical_mut() {
-//                             spherical_joint.set_motor_position(*axis, *position, *stiffness, *dampning);
-//                         }
-//                     }
-//                 }
-//             },
-//             JointEvent::SetVelocitySpherical { entity , axis, velocity, factor } => {
-//                 if let Ok(handle) = query.get_mut(*entity) {
-//                     if let Some(joint) = joint_set.get_mut(handle.0) {
-//                         if let Some(spherical_joint) = joint.data.as_spherical_mut() {
-//                             spherical_joint.set_motor_velocity(*axis, *velocity, *factor);
-//                         }
-//                     }
-//                 }
-//             }
-//         }
-//     }
-// }
+                None => { error!("Could not get joint from joint set")},
+                Some((mb, id)) => match mb.link_mut(id) {
+
+                    None => { error!("Could not get multi joint link from multibody"); },
+                    Some(joint_link) => {
+
+                        match event.action {
+                            MotorAction::PositionRevolute { position, damping, stiffness} => {
+                                match joint_link.joint.data.as_revolute_mut() {
+                                    Some(rev_joint) => { rev_joint.set_motor_position(position, stiffness, damping); },
+                                    None => { info!("Joint was not a revolute joint for revolute joint event"); }
+                                }
+                            },
+                            MotorAction::VelocityRevolute { velocity, factor} => {
+                                match joint_link.joint.data.as_revolute_mut() {
+                                    Some(rev_joint) => { rev_joint.set_motor_velocity(velocity, factor); },
+                                    None => { info!("Joint was not a revolute joint for revolute joint event"); }
+                                }
+                            },
+                            MotorAction::PositionSpherical {axis, position, damping, stiffness} => {
+                                match joint_link.joint.data.as_spherical_mut() {
+                                    Some(rev_joint) => { rev_joint.set_motor_position(axis, position, stiffness, damping); },
+                                    None => { info!("Joint was not a spherical joint for spherical joint event"); }
+                                }
+                            },
+                            MotorAction::VelocitySpherical {axis, velocity, factor} => {
+                                match joint_link.joint.data.as_spherical_mut() {
+                                    Some(spherical_joint) => { spherical_joint.set_motor_velocity(axis, velocity, factor); },
+                                    None => { info!("Joint was not a spherical joint for spherical joint event"); }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
 
 
-// #[cfg(test)]
-// mod tests {
-//     use bevy::ecs::event::Events;
-//     use rapier3d::prelude::ImpulseJointSet;
+#[cfg(test)]
+mod tests {
+    use bevy::ecs::event::Events;
 
-//     use crate::joint::fixed::FixedJoint;
-//     use crate::conversions::IntoRapier;
-//     use super::*;
+    use crate::joint::fixed::FixedJoint;
+    use crate::conversions::IntoRapier;
+    use super::*;
 
-//     #[test]
-//     fn test_add_one_joint() {
+    #[test]
+    fn test_add_one_joint() {
 
-//         let mut world = World::default();
-//         let mut test_stage = SystemStage::parallel();
-//         test_stage.add_system(add_joints_system);
+        let mut world = World::default();
+        let mut test_stage = SystemStage::parallel();
+        test_stage.add_system(add_multibody_joints_system);
 
-//         world.init_resource::<rapier3d::prelude::ImpulseJointSet>();
+        world.init_resource::<rapier3d::prelude::MultibodyJointSet>();
 
-//         let parent_body_handle = rapier::RigidBodyHandle::from_raw_parts(1, 0);
-//         let parent_entity = world
-//             .spawn()
-//             .insert(RigidBodyHandle(parent_body_handle))
-//             .id();
+        let parent_body_handle = rapier::RigidBodyHandle::from_raw_parts(1, 0);
+        let parent_entity = world
+            .spawn()
+            .insert(RigidBodyHandle(parent_body_handle))
+            .id();
 
-//         let expected_transform = Transform::from_translation(Vec3::X);
-//         let joint = Joint::new(parent_entity, FixedJoint {
-//             parent_anchor: expected_transform,
-//             child_anchor: expected_transform
-//         });
+        let expected_transform = Transform::from_translation(Vec3::X);
+        let joint = Joint::new(parent_entity, FixedJoint {
+            parent_anchor: expected_transform,
+            child_anchor: expected_transform
+        });
 
-//         let child_body_handle = rapier::RigidBodyHandle::from_raw_parts(2, 0);
-//         let child_entity = world
-//             .spawn()
-//             .insert(joint)
-//             .insert(RigidBodyHandle(child_body_handle))
-//             .id();
+        let child_body_handle = rapier::RigidBodyHandle::from_raw_parts(2, 0);
+        let child_entity = world
+            .spawn()
+            .insert(joint)
+            .insert(RigidBodyHandle(child_body_handle))
+            .id();
 
-//         let mut entity_body_map = EntityBodyHandleMap::default();
-//         entity_body_map.insert(parent_entity, parent_body_handle);
-//         entity_body_map.insert(child_entity, child_body_handle);
-//         world.insert_resource(entity_body_map);
+        let mut entity_body_map = Entity2BodyHandle::default();
+        entity_body_map.insert(parent_entity, parent_body_handle);
+        entity_body_map.insert(child_entity, child_body_handle);
+        world.insert_resource(entity_body_map);
 
-//         test_stage.run(&mut world);
+        test_stage.run(&mut world);
 
-//         let joint_set = world
-//             .get_resource::<rapier3d::prelude::ImpulseJointSet>()
-//             .expect("Could not get ImpulseJointSet").clone();
+        let multibody_joint_set = world
+            .get_resource::<rapier3d::prelude::MultibodyJointSet>()
+            .expect("Could not get ImpulseJointSet").clone();
 
-//         // only on element in set
-//         assert_eq!(joint_set.len(), 1);
+        // only on element in set
+        assert_eq!(multibody_joint_set.attached_joints(parent_body_handle).count(), 1);
+        assert_eq!(multibody_joint_set.attached_joints(child_body_handle).count(), 1);
 
-//         // only one entity with joint handle, should only be the child
-//         let mut query = world.query::<&MultibodyJointHandle>();
-//         assert_eq!(query.iter(&world).len(), 1);
+        // only one entity with joint handle, should only be the child
+        let mut query = world.query::<&MultibodyJointHandle>();
+        assert_eq!(query.iter(&world).len(), 1);
 
-//         let joint_handle = query.get(&world, child_entity)
-//             .expect("Failed to get JointHandle from query");
+        let joint_handle = query.get(&world, child_entity)
+            .expect("Failed to get JointHandle from query");
 
-//         let joint = joint_set.get(joint_handle.0).expect("Could not get joint from joint set");
+        let (multibody, link_id) = multibody_joint_set.get(joint_handle.0).expect("Could not get joint from joint set");
 
-//         assert_eq!(joint.body1, parent_body_handle);
-//         assert_eq!(joint.body2, child_body_handle);
+        assert_eq!(multibody.root().rigid_body_handle(), parent_body_handle);
+        assert_eq!(multibody.link(link_id).unwrap().rigid_body_handle(), child_body_handle);
 
-//         assert!(joint.data.as_fixed().is_some());
+        let joint = multibody.link(link_id).unwrap().joint;
+        assert!(joint.data.as_fixed().is_some());
+        assert_eq!(joint.data.local_frame1, expected_transform.into_rapier());
+        assert_eq!(joint.data.local_frame2, expected_transform.into_rapier());
 
-//         assert_eq!(joint.data.local_frame1, expected_transform.into_rapier());
-//         assert_eq!(joint.data.local_frame2, expected_transform.into_rapier());
-//     }
+    }
 
-//     fn setup_joint_motor() -> (World, rapier::RigidBodyHandle, rapier::RigidBodyHandle, ImpulseJointSet) {
+    fn setup_joint_motor() -> (World, rapier::RigidBodyHandle, rapier::RigidBodyHandle, rapier::MultibodyJointSet) {
 
-//         let world = World::new();
+        let world = World::new();
 
-//         let joint_set = rapier::ImpulseJointSet::default();
-//         let mut body_set = rapier::RigidBodySet::default();
+        let joint_set = rapier::MultibodyJointSet::default();
+        let mut body_set = rapier::RigidBodySet::default();
 
-//         let body1 = rapier::RigidBodyBuilder::new(rapier::RigidBodyType::Dynamic).build();
-//         let body2 = rapier::RigidBodyBuilder::new(rapier::RigidBodyType::Dynamic).build();
+        let body1 = rapier::RigidBodyBuilder::new(rapier::RigidBodyType::Dynamic).build();
+        let body2 = rapier::RigidBodyBuilder::new(rapier::RigidBodyType::Dynamic).build();
 
-//         let body_handle1 = body_set.insert(body1);
-//         let body_handle2 = body_set.insert(body2);
+        let body_handle1 = body_set.insert(body1);
+        let body_handle2 = body_set.insert(body2);
 
-//         return (world, body_handle1, body_handle2, joint_set);
-//     }
+        return (world, body_handle1, body_handle2, joint_set);
+    }
 
-//     #[test]
-//     fn test_set_joint_velocity_revolute() {
+    #[test]
+    fn test_set_joint_velocity_revolute() {
 
-//         let (mut world, body_handle1, body_handle2, mut joint_set) = setup_joint_motor();
+        let (mut world, body_handle1, body_handle2, mut joint_set) = setup_joint_motor();
 
-//         // create and insert joint
-//         let joint = rapier::RevoluteJointBuilder::new(rapier::Vector::x_axis()).build();
-//         let joint_handle = joint_set.insert(body_handle1, body_handle2, joint);
+        // create and insert joint
+        let joint = rapier::RevoluteJointBuilder::new(rapier::Vector::x_axis()).build();
+        let joint_handle = joint_set.insert(body_handle1, body_handle2, joint, true).unwrap();
 
-//         world.insert_resource(joint_set);
-//         let entity = world.spawn().insert(MultibodyJointHandle(joint_handle)).id();
+        world.insert_resource(joint_set);
+        let entity = world.spawn().insert(MultibodyJointHandle(joint_handle)).id();
 
-//         // Setup and send test event for setting the velocity
-//         let expected_vel = 2.3;
-//         let expected_factor = 3.4;
-//         let mut events = Events::<JointEvent>::default();
-//         events.send(JointEvent::SetVelocityRevolute { entity: entity, velocity: expected_vel, factor: expected_factor });
-//         world.insert_resource(events);
+        // Setup and send test event for setting the velocity
+        let expected_vel = 2.3;
+        let expected_factor = 3.4;
+        let mut events = Events::<JointMotorEvent>::default();
+        events.send(JointMotorEvent { entity: entity, action: MotorAction::VelocityRevolute { velocity: expected_vel, factor: expected_factor }});
+        world.insert_resource(events);
 
-//         // Run stage
-//         let test_stage = SystemStage::parallel();
-//         test_stage.with_system(update_joint_motors_system).run(&mut world);
+        // Run stage
+        let test_stage = SystemStage::parallel();
+        test_stage.with_system(update_joint_motors_system).run(&mut world);
         
-//         // get result
-//         let res_set = world.get_resource::<rapier::ImpulseJointSet>().expect("Could not get impule joint set");
-//         let res_joint = res_set.get(joint_handle).expect("Could not get joint from joint set");
+        // get result
+        let res_set = world.get_resource::<rapier::MultibodyJointSet>().expect("Could not get impule joint set");
+        let (multibody, link_id) = res_set.get(joint_handle).expect("Could not get joint from joint set");
 
-//         // test correct values
-//         assert_eq!(res_joint.data.as_revolute().unwrap().motor().unwrap().target_vel, expected_vel);
-//         assert_eq!(res_joint.data.as_revolute().unwrap().motor().unwrap().damping, expected_factor);
+        // test correct values
+        let res_joint = multibody.link(link_id).unwrap().joint;
+        assert_eq!(res_joint.data.as_revolute().unwrap().motor().unwrap().target_vel, expected_vel);
+        assert_eq!(res_joint.data.as_revolute().unwrap().motor().unwrap().damping, expected_factor);
 
-//     }
+    }
 
-//     #[test]
-//     fn test_set_joint_position_revolute() {
+    #[test]
+    fn test_set_joint_position_revolute() {
 
-//         let (mut world, body_handle1, body_handle2, mut joint_set) = setup_joint_motor();
+        let (mut world, body_handle1, body_handle2, mut joint_set) = setup_joint_motor();
 
-//         // create and insert joint
-//         let joint = rapier::RevoluteJointBuilder::new(rapier::Vector::x_axis()).build();
-//         let joint_handle = joint_set.insert(body_handle1, body_handle2, joint);
+        // create and insert joint
+        let joint = rapier::RevoluteJointBuilder::new(rapier::Vector::x_axis()).build();
+        let joint_handle = joint_set.insert(body_handle1, body_handle2, joint, true).unwrap();
 
-//         world.insert_resource(joint_set);
-//         let entity = world.spawn().insert(MultibodyJointHandle(joint_handle)).id();
+        world.insert_resource(joint_set);
+        let entity = world.spawn().insert(MultibodyJointHandle(joint_handle)).id();
 
-//         // Setup and send test event for setting the velocity
-//         let expected_pos = 2.3;
-//         let expected_dampning = 3.4;
-//         let expected_stiffness = 4.5;
-//         let mut events = Events::<JointEvent>::default();
-//         events.send(JointEvent::SetPositionRevolute { 
-//             entity, 
-//             position: expected_pos, 
-//             dampning: expected_dampning,
-//             stiffness: expected_stiffness
-//         });
-//         world.insert_resource(events);
+        // Setup and send test event for setting the velocity
+        let expected_pos = 2.3;
+        let expected_dampning = 3.4;
+        let expected_stiffness = 4.5;
+        let mut events = Events::<JointMotorEvent>::default();
+        events.send(JointMotorEvent { 
+            entity, 
+            action: MotorAction::PositionRevolute { 
+                position: expected_pos, 
+                damping: expected_dampning,
+                stiffness: expected_stiffness
+            }
+        });
+        world.insert_resource(events);
 
-//         // Run stage
-//         let test_stage = SystemStage::parallel();
-//         test_stage.with_system(update_joint_motors_system).run(&mut world);
+        // Run stage
+        let test_stage = SystemStage::parallel();
+        test_stage.with_system(update_joint_motors_system).run(&mut world);
         
-//         // get result
-//         let res_set = world.get_resource::<rapier::ImpulseJointSet>().expect("Could not get impule joint set");
-//         let res_joint = res_set.get(joint_handle).expect("Could not get joint from joint set");
+        // get result
+        let res_set = world.get_resource::<rapier::MultibodyJointSet>().expect("Could not get impule joint set");
+        let (multibody, link_id) = res_set.get(joint_handle).expect("Could not get joint from joint set");
 
-//         // test correct values
-//         assert_eq!(res_joint.data.as_revolute().unwrap().motor().unwrap().target_pos, expected_pos);
-//         assert_eq!(res_joint.data.as_revolute().unwrap().motor().unwrap().damping, expected_dampning);
-//         assert_eq!(res_joint.data.as_revolute().unwrap().motor().unwrap().stiffness, expected_stiffness);
+        // test correct values
+        let res_joint = multibody.link(link_id).unwrap().joint;
+        assert_eq!(res_joint.data.as_revolute().unwrap().motor().unwrap().target_pos, expected_pos);
+        assert_eq!(res_joint.data.as_revolute().unwrap().motor().unwrap().damping, expected_dampning);
+        assert_eq!(res_joint.data.as_revolute().unwrap().motor().unwrap().stiffness, expected_stiffness);
 
-//     }
+    }
 
-//     #[test]
-//     fn test_set_joint_velocity_spherical() {
+    #[test]
+    fn test_set_joint_velocity_spherical() {
 
-//         let (mut world, body_handle1, body_handle2, mut joint_set) = setup_joint_motor();
+        let (mut world, body_handle1, body_handle2, mut joint_set) = setup_joint_motor();
 
-//         // create and insert joint
-//         let joint = rapier::SphericalJointBuilder::new().build();
-//         let joint_handle = joint_set.insert(body_handle1, body_handle2, joint);
+        // create and insert joint
+        let joint = rapier::SphericalJointBuilder::new().build();
+        let joint_handle = joint_set.insert(body_handle1, body_handle2, joint, true).unwrap();
 
-//         world.insert_resource(joint_set);
-//         let entity = world.spawn().insert(MultibodyJointHandle(joint_handle)).id();
+        world.insert_resource(joint_set);
+        let entity = world.spawn().insert(MultibodyJointHandle(joint_handle)).id();
 
-//         // Setup and send test event for setting the velocity
-//         let expected_vel = 2.3;
-//         let expected_factor = 3.4;
-//         let test_axis = rapier::JointAxis::AngX;
-//         let mut events = Events::<JointEvent>::default();
-//         events.send(JointEvent::SetVelocitySpherical { 
-//             entity: entity, 
-//             velocity: expected_vel, 
-//             axis: test_axis, 
-//             factor: expected_factor 
-//         });
-//         world.insert_resource(events);
+        // Setup and send test event for setting the velocity
+        let expected_vel = 2.3;
+        let expected_factor = 3.4;
+        let test_axis = rapier::JointAxis::AngX;
+        let mut events = Events::<JointMotorEvent>::default();
+        events.send(JointMotorEvent { 
+            entity: entity, 
+            action: MotorAction::VelocitySpherical {
+                velocity: expected_vel, 
+                axis: test_axis, 
+                factor: expected_factor 
+            }
+        });
+        world.insert_resource(events);
 
-//         // Run stage
-//         let test_stage = SystemStage::parallel();
-//         test_stage.with_system(update_joint_motors_system).run(&mut world);
+        // Run stage
+        let test_stage = SystemStage::parallel();
+        test_stage.with_system(update_joint_motors_system).run(&mut world);
         
-//         // get result
-//         let res_set = world.get_resource::<rapier::ImpulseJointSet>().expect("Could not get impule joint set");
-//         let res_joint = res_set.get(joint_handle).expect("Could not get joint from joint set");
+        // get result
+        let res_set = world.get_resource::<rapier::MultibodyJointSet>().expect("Could not get impule joint set");
+        let (multibody, link_id) = res_set.get(joint_handle).expect("Could not get joint from joint set");
 
-//         // test correct values
-//         assert_eq!(res_joint.data.as_spherical().unwrap().motor(test_axis).unwrap().target_vel, expected_vel);
-//         assert_eq!(res_joint.data.as_spherical().unwrap().motor(test_axis).unwrap().damping, expected_factor);
+        // test correct values
+        let res_joint = multibody.link(link_id).unwrap().joint;
+        assert_eq!(res_joint.data.as_spherical().unwrap().motor(test_axis).unwrap().target_vel, expected_vel);
+        assert_eq!(res_joint.data.as_spherical().unwrap().motor(test_axis).unwrap().damping, expected_factor);
 
-//     }
+    }
 
-//     #[test]
-//     fn test_set_joint_position_spherical() {
+    #[test]
+    fn test_set_joint_position_spherical() {
 
-//         let (mut world, body_handle1, body_handle2, mut joint_set) = setup_joint_motor();
+        let (mut world, body_handle1, body_handle2, mut joint_set) = setup_joint_motor();
 
-//         // create and insert joint
-//         let joint = rapier::SphericalJointBuilder::new().build();
-//         let joint_handle = joint_set.insert(body_handle1, body_handle2, joint);
+        // create and insert joint
+        let joint = rapier::SphericalJointBuilder::new().build();
+        let joint_handle = joint_set.insert(body_handle1, body_handle2, joint, true).unwrap();
 
-//         world.insert_resource(joint_set);
-//         let entity = world.spawn().insert(MultibodyJointHandle(joint_handle)).id();
+        world.insert_resource(joint_set);
+        let entity = world.spawn().insert(MultibodyJointHandle(joint_handle)).id();
 
-//         // Setup and send test event for setting the velocity
-//         let expected_pos = 2.3;
-//         let expected_dampning = 3.4;
-//         let expected_stiffness = 4.5;
-//         let test_axis = rapier::JointAxis::AngY;
-//         let mut events = Events::<JointEvent>::default();
-//         events.send(JointEvent::SetPositionSpherical { 
-//             entity, 
-//             position: expected_pos, 
-//             axis: test_axis,
-//             dampning: expected_dampning,
-//             stiffness: expected_stiffness
-//         });
-//         world.insert_resource(events);
+        // Setup and send test event for setting the velocity
+        let expected_pos = 2.3;
+        let expected_dampning = 3.4;
+        let expected_stiffness = 4.5;
+        let test_axis = rapier::JointAxis::AngY;
+        let mut events = Events::<JointMotorEvent>::default();
+        events.send(JointMotorEvent { 
+            entity, 
+            action: MotorAction::PositionSpherical {
+                position: expected_pos, 
+                axis: test_axis,
+                damping: expected_dampning,
+                stiffness: expected_stiffness
+            }
+        });
+        world.insert_resource(events);
 
-//         // Run stage
-//         let test_stage = SystemStage::parallel();
-//         test_stage.with_system(update_joint_motors_system).run(&mut world);
+        // Run stage
+        let test_stage = SystemStage::parallel();
+        test_stage.with_system(update_joint_motors_system).run(&mut world);
         
-//         // get result
-//         let res_set = world.get_resource::<rapier::ImpulseJointSet>().expect("Could not get impule joint set");
-//         let res_joint = res_set.get(joint_handle).expect("Could not get joint from joint set");
+        // get result
+        let res_set = world.get_resource::<rapier::MultibodyJointSet>().expect("Could not get impule joint set");
+        let (multibody, link_id) = res_set.get(joint_handle).expect("Could not get joint from joint set");
 
-//         // test correct values
-//         assert_eq!(res_joint.data.as_spherical().unwrap().motor(test_axis).unwrap().target_pos, expected_pos);
-//         assert_eq!(res_joint.data.as_spherical().unwrap().motor(test_axis).unwrap().damping, expected_dampning);
-//         assert_eq!(res_joint.data.as_spherical().unwrap().motor(test_axis).unwrap().stiffness, expected_stiffness);
+        // test correct values
+        let res_joint = multibody.link(link_id).unwrap().joint;
+        assert_eq!(res_joint.data.as_spherical().unwrap().motor(test_axis).unwrap().target_pos, expected_pos);
+        assert_eq!(res_joint.data.as_spherical().unwrap().motor(test_axis).unwrap().damping, expected_dampning);
+        assert_eq!(res_joint.data.as_spherical().unwrap().motor(test_axis).unwrap().stiffness, expected_stiffness);
 
-//     }
+    }
 
-// }
+}

--- a/crates/nora_physics/src/multibody.rs
+++ b/crates/nora_physics/src/multibody.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+
+use bevy::prelude::*;
+use rapier3d::prelude as rapier;
+
+use crate::rigid_body::{RigidBodyHandle, BodyHandle2Entity, RigidBodyName};
+
+
+/// Component to indicate that the entity is a multibody root entity
+#[derive(Component)]
+pub struct MultibodyRoot {
+    /// map from rigidbody name to entity
+    pub joints: HashMap<String, Entity>
+}
+
+/// Component to indicate that the entity is a multibody
+#[derive(Component)]
+pub struct MultiBody;
+
+/// Component to indicate that the entity is not a multibody
+#[derive(Component)]
+pub struct NotMultibody;
+
+/// Sytem that adds components related to multibodies
+/// 
+/// Todo: Look how to improve this, now it feels a bit complicated and not clear.
+pub(crate) fn add_multibody_components_system(
+    mut commands: Commands,
+    multibody_joint_set: Res<rapier::MultibodyJointSet>,
+    body_2_entity: Res<BodyHandle2Entity>,
+    query: Query<
+        (Entity, &RigidBodyHandle, Option<&RigidBodyName>), 
+        (With<RigidBodyHandle>, Without<NotMultibody>, Without<MultibodyRoot>)
+    >
+) {
+
+    for (entity, handle, _) in query.iter() {
+
+        if let Some(body) = multibody_joint_set.rigid_body_link(handle.0) {
+            if let Some(mb) = multibody_joint_set.get_multibody(body.multibody) {
+                if handle.0 == mb.root().rigid_body_handle() {
+
+                    // we have the root of the multibody -> create a map from name of the bodies
+                    // in the multi body to the entity id
+                    let mut joints = HashMap::<String, Entity>::new();
+                    for link in mb.links() {
+
+                        let link_entity = body_2_entity.get(&link.rigid_body_handle()).expect("body should be in body to entity map");
+                        match query.get(*link_entity) {
+                            Ok((_, _, name)) => {
+                                if let Some(name) = name {
+                                    joints.insert(name.0.clone(), *link_entity);
+                                }
+                            },
+                            Err(e) => error!("{e}")
+                        }
+                    }
+                    commands.entity(entity).insert(MultibodyRoot { joints });
+
+                } else {
+                    // not a root
+                    commands.entity(entity).insert(MultiBody);
+                }
+            }
+        } else {
+            // not a multibody
+            commands.entity(entity).insert(NotMultibody);
+        }
+    }
+}

--- a/examples/car.rs
+++ b/examples/car.rs
@@ -1,0 +1,42 @@
+use bevy::prelude::*;
+use nora_core::{
+    diagnostic::event::DebugEventPlugin,
+    plugins::CorePlugins,
+};
+use nora_lib::models;
+
+
+fn main() {
+    App::new()
+    .add_plugins(DefaultPlugins)
+    .add_plugins(CorePlugins)
+    .add_plugin(DebugEventPlugin)
+    .add_startup_system(setup_scene)
+    .add_plugin(models::car::CarPlugin)
+    .run();
+}
+
+fn setup_scene(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>
+) {
+
+    models::arena::spawn_arena(
+        &mut commands, 
+        materials.add(Color::SALMON.into()), 
+        &mut meshes, 
+        10.0, 10.0, 1.0
+    );
+
+    // Light
+    commands.spawn_bundle(DirectionalLightBundle {
+        directional_light: DirectionalLight {
+            illuminance: 50000.0,
+            ..Default::default()
+        },
+        transform: Transform::from_xyz(20.0, 40.0, -40.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
+
+}


### PR DESCRIPTION
Multibody components gets added behind the scene when attaching joints between bodies. Components that indicates if the entity is a multi body root, multibody child or just a single body is added.

Also
- reactivated and updated joint tests
- added car example with controls (wasd keys)
- bumped rapier version to 0.13.0