### PR TITLE
multibody name registry

### DIFF
--- a/crates/nora_physics/src/lib.rs
+++ b/crates/nora_physics/src/lib.rs
@@ -81,6 +81,9 @@ impl Plugin for PhysicsPlugin {
 
             .insert_resource(Gravity::new(self.gravity))
 
+            // Multibody name registry, making sure all multibodies have unique names
+            .insert_resource(multibody::MultibodyNameRegistry::new())
+
             .add_event::<joint::JointMotorEvent>()
             
             .add_system_set_to_stage(

--- a/crates/nora_physics/src/multibody.rs
+++ b/crates/nora_physics/src/multibody.rs
@@ -18,8 +18,31 @@ pub struct MultibodyRoot {
 /// Component to indicate that the entity is a multibody child entity
 #[derive(Component)]
 pub struct MultiBodyChild {
+    pub name: String,
     pub root: Entity,
     pub joints: HashMap<String, Entity>
+}
+
+pub struct MultibodyNameRegistry {
+    names: HashMap<String, i32>
+}
+
+impl MultibodyNameRegistry {
+    pub fn new() -> Self {
+        Self {
+            names: HashMap::<String, i32>::new()
+        }
+    }
+
+    pub fn create_unique_name(&mut self, name: &String) -> String {
+
+        if self.names.contains_key(name) {
+            *self.names.get_mut(name).expect("") += 1;
+        } else {
+            self.names.insert(name.clone(), 0);
+        }
+        return format!("{}-{}", name, self.names.get(name).unwrap());
+    }
 }
 
 /// System that adds components related to multibodies
@@ -28,6 +51,7 @@ pub struct MultiBodyChild {
 #[allow(clippy::type_complexity)]
 pub(crate) fn add_multibody_components_system(
     mut commands: Commands,
+    mut name_registry: ResMut<MultibodyNameRegistry>,
     multibody_joint_set: Res<rapier::MultibodyJointSet>,
     body_2_entity: Res<BodyHandle2Entity>,
     query: Query<
@@ -43,10 +67,9 @@ pub(crate) fn add_multibody_components_system(
 
             // get the multibody of the link
             if let Some(multibody) = multibody_joint_set.get_multibody(body_joint_link.multibody) {
-
+                
                 // build a hash map with names and entity to store in the component.
                 // the component can later be used to easy get hold of different links and joints
-                // TODO: Make sure you don't add self in the map and keep that in a separate var instead
                 let mut joints = HashMap::<String, Entity>::new();
                 for link in multibody.links() {
 
@@ -63,18 +86,24 @@ pub(crate) fn add_multibody_components_system(
                     }
                 }
 
+                let mut name = if let Some(body_name) = body_name {
+                    body_name.0.clone()
+                } else {
+                    // if we don't have a name use the entity id
+                    entity.id().to_string()
+                };
+
                 if handle.0 == multibody.root().rigid_body_handle() {
-                    let name = if let Some(body_name) = body_name {
-                        body_name.0.clone()
-                    } else {
-                        entity.id().to_string()
-                    };
+                    // We have a root
+                    // make the name unique
+                    name = name_registry.create_unique_name(&name);
                     commands.entity(entity).insert(MultibodyRoot { name, joints });
                 } else {
                     // not a root
                     let root_rigid_body_handle = multibody.root().rigid_body_handle();
                     let root_entity = body_2_entity.get(&root_rigid_body_handle).expect("Every rigid body should be connected to an entity");
                     commands.entity(entity).insert(MultiBodyChild { 
+                        name,
                         root: *root_entity, 
                         joints
                     });


### PR DESCRIPTION
resource that creates a unique name for a multibody root. Implemented as a hash map that keeps a counter for each name.