### PR TITLE
block dragging if not holding over an object

### DIFF
--- a/crates/nora_object_interaction/src/lib.rs
+++ b/crates/nora_object_interaction/src/lib.rs
@@ -11,7 +11,7 @@ use interaction::Select;
 use nora_raycast::{RayCastSource, RayCastSystems, RayVisible, RayCastPlugin};
 use crate::{
     interaction::{
-        DraggingGlobal, update_interactions,
+        GlobalDragState, update_interactions,
         Drag, Hover
     },
     event::InteractionEvent,
@@ -42,7 +42,7 @@ where T: Component + Default
         app.init_resource::<InteractionMaterials>()
             .add_event::<InteractionEvent>()
             .add_event::<SelectEvent>()
-            .init_resource::<DraggingGlobal>()
+            .init_resource::<GlobalDragState>()
             .add_plugin(RayCastPlugin::<T>::default())
             .add_system_set_to_stage(
                 CoreStage::First,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,14 @@ fn test_scene(
         &mut meshes,
     );
 
+    models::wheely::Wheely::spawn_wheely(
+        &mut commands,
+        materials.add(Color::FUCHSIA.into()), 
+        materials.add(Color::DARK_GRAY.into()), 
+        Transform::from_xyz(-2.0, 2.0, -2.0),
+        &mut meshes,
+    );
+
     // spawn sphere that will generate collision events
     commands.spawn_bundle(PbrBundle {
         material: materials.add(Color::PURPLE.into()),


### PR DESCRIPTION
previously if you pressed the left mouse button and did not hover over an object an object would be dragged as soon as the cursor was over that object. This is fixed by blocking dragging in this scenario