### PR TITLE
exploring control by selection

### DIFF
--- a/crates/nora_core/src/interaction/multibody_selection.rs
+++ b/crates/nora_core/src/interaction/multibody_selection.rs
@@ -47,7 +47,7 @@ pub fn multibody_selection_system(
                     true => multibody_select_event_writer.send(MultibodySelectionEvent::Selected(root_entity)),
                     false => multibody_select_event_writer.send(MultibodySelectionEvent::Deselected(root_entity))
                 }
-                (Some(&multi_root.joints), Some(root_entity))
+                (Some(&multi_root.joint_name_2_entity), Some(root_entity))
             } else if let Ok((multi_child, _)) = child_query.get(*entity) {
                 (Some(&multi_child.joints), Some(multi_child.root))
             } else {

--- a/crates/nora_core/src/models/car.rs
+++ b/crates/nora_core/src/models/car.rs
@@ -363,13 +363,13 @@ fn handle_car_control_system(
                         CarVelocity::NoVelocity => (0.0, controller.damping)
                     };
 
-                    if let Some(entity) = car_body.joints.get(RIGHT_REAR_WHEEL) {
+                    if let Some(entity) = car_body.joint_name_2_entity.get(RIGHT_REAR_WHEEL) {
                         joint_event_writer.send(JointMotorEvent {
                             entity: *entity,
                             action: MotorAction::VelocityRevolute { velocity: -velocity, factor }
                         });
                     }
-                    if let Some(entity) = car_body.joints.get(LEFT_REAR_WHEEL) {
+                    if let Some(entity) = car_body.joint_name_2_entity.get(LEFT_REAR_WHEEL) {
                         joint_event_writer.send(JointMotorEvent {
                             entity: *entity,
                             action: MotorAction::VelocityRevolute { velocity, factor }
@@ -390,7 +390,7 @@ fn handle_car_control_system(
                         }
                     };
 
-                    if let Some(entity) = car_body.joints.get(LEFT_FRONT_WHEEL_TURN) {
+                    if let Some(entity) = car_body.joint_name_2_entity.get(LEFT_FRONT_WHEEL_TURN) {
                         joint_event_writer.send(JointMotorEvent { 
                             entity: *entity,
                             action: MotorAction::PositionRevolute { position: -position, damping, stiffness } })
@@ -398,7 +398,7 @@ fn handle_car_control_system(
                         error!("Could not get {}", LEFT_FRONT_WHEEL_TURN);
                     }
 
-                    if let Some(entity) = car_body.joints.get(RIGHT_FRONT_WHEEL_TURN) {
+                    if let Some(entity) = car_body.joint_name_2_entity.get(RIGHT_FRONT_WHEEL_TURN) {
                         joint_event_writer.send(JointMotorEvent { 
                             entity: *entity,
                             action: MotorAction::PositionRevolute { position, damping, stiffness } })

--- a/crates/nora_core/src/ui/multibody_component.rs
+++ b/crates/nora_core/src/ui/multibody_component.rs
@@ -71,7 +71,7 @@ impl MultibodyUIComponent {
                 if comp.multibody_joints.is_none() {
                     // Build map with relevant joint data to be displayed
                     let mut joints = HashMap::<Entity, JointData>::new();
-                    for (name, entity) in root.joints.iter() {
+                    for (name, entity) in root.joint_name_2_entity.iter() {
                         if let Ok(joint) = joint_query.get(*entity) {
 
                             // check which type of joint we are dealing with and add it to the component

--- a/crates/nora_physics/src/joint.rs
+++ b/crates/nora_physics/src/joint.rs
@@ -190,6 +190,10 @@ pub enum MotorAction {
         position: f32,
         damping: f32,
         stiffness: f32,
+    },
+    VelocityPrismatic {
+        velocity: f32,
+        factor: f32
     }
 }
 
@@ -238,6 +242,12 @@ pub(crate) fn update_joint_motors_system(
                             MotorAction::PositionPrismatic { position, damping, stiffness } => {
                                 match joint_link.joint.data.as_prismatic_mut() {
                                     Some(prismatic_joint) => { prismatic_joint.set_motor_position(position, stiffness, damping); }
+                                    None => { info!("Joint was not a prismatic joint for prismatic joint event"); }
+                                }
+                            },
+                            MotorAction::VelocityPrismatic { velocity, factor } => {
+                                match joint_link.joint.data.as_prismatic_mut() {
+                                    Some(prismatic_joint) => { prismatic_joint.set_motor_velocity(velocity, factor); }
                                     None => { info!("Joint was not a prismatic joint for prismatic joint event"); }
                                 }
                             }

--- a/crates/nora_physics/src/multibody.rs
+++ b/crates/nora_physics/src/multibody.rs
@@ -12,7 +12,7 @@ pub struct MultibodyRoot {
     // Name of the multibody
     pub name: String,
     /// map from rigidbody name to entity that has a reference to a joint
-    pub joints: HashMap<String, Entity>
+    pub joint_name_2_entity: HashMap<String, Entity>
 }
 
 /// Component to indicate that the entity is a multibody child entity
@@ -98,7 +98,7 @@ pub(crate) fn add_multibody_components_system(
                     // We have a root
                     // make the name unique
                     name = name_registry.create_unique_name(&name);
-                    commands.entity(entity).insert(MultibodyRoot { name, joints });
+                    commands.entity(entity).insert(MultibodyRoot { name, joint_name_2_entity: joints });
                 } else {
                     // not a root
                     let root_rigid_body_handle = multibody.root().rigid_body_handle();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,10 @@ use bevy::prelude::*;
 use nora_core::{
     plugins::CorePlugins,
     diagnostic::DiagnosticsPlugins,
-    interaction::groups::GroupDynamic
+    interaction::groups::GroupDynamic, 
+    models,
+    models::car::CarPlugin,
+    models::wheely::WheelyPlugin
 };
 use nora_physics::{
     rigid_body::RigidBody,
@@ -13,10 +16,6 @@ use nora_physics::{
     event::GenerateCollisionEvents
 };
 use nora_object_interaction::InteractiveBundle;
-use nora_core::{
-    models,
-    models::car::CarPlugin
-};
 
 
 fn main() {
@@ -24,6 +23,7 @@ fn main() {
     .add_plugins(CorePlugins)
     .add_plugins(DiagnosticsPlugins)
     .add_plugin(CarPlugin)
+    .add_plugin(WheelyPlugin)
     .add_startup_system(test_scene)
     .run();
 }


### PR DESCRIPTION
to control a Wheely robot you now just need to select it. Then a controller commponent gets added. also a plugin for each model need to exists that includes systems for handling the control events and keyboard mapping.