### PR TITLE
tcp communication stages

### DIFF
--- a/crates/kesko_core/src/event.rs
+++ b/crates/kesko_core/src/event.rs
@@ -1,28 +1,138 @@
 use bevy::prelude::*;
 use bevy::app::AppExit;
-use kesko_physics::event::PhysicStateEvent;
+use bevy::utils::hashbrown::HashMap;
+
+use kesko_physics::{
+    event::PhysicStateEvent,
+    multibody::{
+        MultibodyRoot,
+        MultiBodyChild,
+        MultiBodyState,
+        MultiBodyStates
+    },
+    joint::{
+        Joint,
+        JointState,
+        JointMotorEvent, MotorAction,
+    }
+};
 
 
-pub enum SystemEvent {
+pub enum SystemRequestEvent {
     SpawnModel,
     PausePhysics,
-    RunPhysics,
-    Exit
+    StartPhysics,
+    GetState,
+    ExitApp,
+    IsAlive,
+    ApplyMotorCommand {
+        body_name: String,
+        command: HashMap<String, f32>
+    }
+}
+
+pub enum SystemResponseEvent {
+    State(MultiBodyStates),
+    SpawnedModel,
+    PausedPhysics,
+    StartedPhysics,
+    WillExitApp,
+    Alive
 }
 
 pub fn handle_system_events(
-    mut system_events: EventReader<SystemEvent>,
+    mut system_requests: EventReader<SystemRequestEvent>,
+    mut system_response_writer: EventWriter<SystemResponseEvent>,
     mut app_exit_events: EventWriter<AppExit>,
     mut physics_events: EventWriter<PhysicStateEvent>,
 ) {
-    for event in system_events.iter() {
+    for event in system_requests.iter() {
         match event {
-            SystemEvent::Exit => {
+            SystemRequestEvent::ExitApp => {
                 app_exit_events.send_default();
+                system_response_writer.send(SystemResponseEvent::WillExitApp);
             },
-            SystemEvent::PausePhysics => physics_events.send(PhysicStateEvent::Pause),
-            SystemEvent::RunPhysics => physics_events.send(PhysicStateEvent::Run),
+            SystemRequestEvent::PausePhysics => {
+                physics_events.send(PhysicStateEvent::Pause);
+                system_response_writer.send(SystemResponseEvent::PausedPhysics);
+            },
+            SystemRequestEvent::StartPhysics => {
+                physics_events.send(PhysicStateEvent::Run);
+                system_response_writer.send(SystemResponseEvent::StartedPhysics);
+            },
+            SystemRequestEvent::IsAlive => system_response_writer.send(SystemResponseEvent::Alive),
             _ => {}
+        }
+    }
+}
+
+pub fn handle_motor_command_requests(
+    mut system_requests: EventReader<SystemRequestEvent>,
+    mut motor_event_writer: EventWriter<JointMotorEvent>,
+    multibody_root_query: Query<&MultibodyRoot>,
+) {
+    for event in system_requests.iter() {
+        if let SystemRequestEvent::ApplyMotorCommand { body_name, command } = event {
+            for root in multibody_root_query.iter() {
+                if root.name == *body_name {
+                    for (joint_name, val) in command.iter() {
+                        if let Some(e) = root.joint_name_2_entity.get(joint_name) {
+                            motor_event_writer.send(JointMotorEvent {
+                                entity: *e,
+                                action: MotorAction::PositionRevolute { position: *val, damping: 0.0, stiffness: 1.0 }
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn handle_serializable_state_request(
+    mut system_requests: EventReader<SystemRequestEvent>,
+    mut system_response_writer: EventWriter<SystemResponseEvent>,
+    multibody_root_query: Query<(&MultibodyRoot, &Transform)>,
+    multibody_child_query: Query<(&MultiBodyChild, &Transform)>,
+    joint_query: Query<&Joint>
+) {
+
+    for event in system_requests.iter() {
+        if let SystemRequestEvent::GetState = event {
+            let states = multibody_root_query.iter().map(|(root, transform)| {
+                
+                // get positions of all the child bodies
+                let child_positions: HashMap<String, Vec3> = root.joint_name_2_entity.iter().map(|(name, entity)| {
+                    let position = match multibody_child_query.get(*entity) {
+                        Ok((_, transform)) => transform.translation,
+                        Err(_) => Vec3::ZERO
+                    };
+                    (name.clone(), position)
+                }).collect();
+
+                // Get joint angles
+                let joint_states: HashMap<String, Option<JointState>> = root.joint_name_2_entity.iter().map(|(name, e)| {
+                    let orientation = match joint_query.get(*e) {
+                        Ok(joint) => {
+                            Some(joint.get_state())
+                        }
+                        Err(_) => None
+                    };
+                    (name.clone(), orientation)
+                }).collect();
+
+                MultiBodyState {
+                    name: root.name.clone(),
+                    global_position: transform.translation,
+                    global_orientation: transform.rotation.to_euler(EulerRot::XYZ).into(),
+                    global_angular_velocity: root.angvel,
+                    relative_positions: Some(child_positions),
+                    joint_states: Some(joint_states)
+                }
+
+            }).collect::<Vec<MultiBodyState>>();
+
+            system_response_writer.send(SystemResponseEvent::State(MultiBodyStates { multibody_states: states }));
         }
     }
 }

--- a/crates/kesko_core/src/lib.rs
+++ b/crates/kesko_core/src/lib.rs
@@ -67,11 +67,21 @@ impl Plugin for CorePlugin {
             .add_system(multibody_selection_system)
             .add_event::<MultibodySelectionEvent>()
 
+            // simulator system events
+            .add_event::<event::SystemRequestEvent>()
+            .add_event::<event::SystemResponseEvent>()
+            .add_system_set_to_stage(
+                CoreStage::Last,
+                SystemSet::new()
+                    .with_system(event::handle_system_events)
+                    .with_system(event::handle_serializable_state_request)
+                    .with_system(event::handle_motor_command_requests)
+            )
+
             // close on ESC
             .add_system(bevy::window::close_on_esc);
     }
 }
-
 
 pub fn change_physic_state(
     mut keys: ResMut<Input<KeyCode>>,

--- a/crates/kesko_physics/src/joint.rs
+++ b/crates/kesko_physics/src/joint.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 use rapier3d::prelude as rapier;
 use rapier3d::dynamics::GenericJoint;
 pub use rapier3d::prelude::{JointLimits, JointAxis};
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 use crate::rigid_body::{Entity2BodyHandle, RigidBodyHandle};
 use crate::conversions::{IntoBevy, IntoRapier};
@@ -31,7 +31,7 @@ impl AxisIntoVec for Axis {
 }
 
 /// Override Rapiers JointAxis since it did not inlcude negative axis
-#[derive(Clone, Copy, Serialize)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub enum Axis {
     X,
     Y,
@@ -42,7 +42,7 @@ pub enum Axis {
 }
 
 /// used to send joint state outside Kesko
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase", tag = "type")]
 pub enum JointState {
     Spherical{ 

--- a/crates/kesko_physics/src/lib.rs
+++ b/crates/kesko_physics/src/lib.rs
@@ -105,7 +105,8 @@ impl Plugin for PhysicsPlugin {
             .add_event::<event::PhysicStateEvent>()
             .add_event::<joint::JointMotorEvent>()
             
-            .add_system_set(
+            .add_system_set_to_stage(
+                CoreStage::Update,
                 SystemSet::on_update(PhysicState::Run)
                     .label("physics-systems")
                     .with_system(

--- a/crates/kesko_physics/src/multibody.rs
+++ b/crates/kesko_physics/src/multibody.rs
@@ -1,7 +1,9 @@
 use bevy::prelude::*;
 use bevy::utils::hashbrown::HashMap;
 use rapier3d::prelude as rapier;
-use serde::Serialize;
+use serde::{
+    Serialize, Deserialize
+};
 
 use crate::{
     rigid_body::{
@@ -14,9 +16,13 @@ use crate::{
     joint::JointState
 };
 
+#[derive(Serialize, Deserialize, Clone)]
+pub struct MultiBodyStates {
+    pub multibody_states: Vec<MultiBodyState>
+}
 
 /// Used for sending data outside of Kesko
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct MultiBodyState {
     pub name: String,
     pub global_position: Vec3,

--- a/crates/kesko_tcp/Cargo.toml
+++ b/crates/kesko_tcp/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 [dependencies]
 serde = "1.0.137"
 serde_json = "1.0.81"
+serde_traitobject = "0.2.7"
 bevy = "0.8.0"
+iyes_loopless = { git = "https://github.com/IyesGames/iyes_loopless.git", branch = "main"}
 kesko_core = { version = "0.1.0", path = "../kesko_core" }
 kesko_physics = { path = "../kesko_physics" }
 kesko_models = { path = "../kesko_models" }

--- a/crates/kesko_tcp/src/lib.rs
+++ b/crates/kesko_tcp/src/lib.rs
@@ -1,29 +1,16 @@
 mod response;
 mod request;
 
-use std::net::{TcpListener, TcpStream};
-use std::io::prelude::*;
+use std::net::TcpListener;
 
 use bevy::prelude::*;
-use bevy::utils::hashbrown::HashMap;
-use kesko_physics::joint::JointState;
-use serde_json;
-
-use kesko_models::SpawnEvent;
-use kesko_physics::{
-    multibody::{MultibodyRoot, MultiBodyChild, MultiBodyState},
-    joint::Joint
-};
-use kesko_core::event::SystemEvent;
-
-use request::{SimHttpRequest, SimAction};
-use response::Response;
+use iyes_loopless::prelude::*;
 
 
 const URL: &str = "127.0.0.1:8080";
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-enum TCPConnectionState {
+enum TcpConnectionState {
     NotConnected,
     Connected
 }
@@ -45,19 +32,30 @@ pub struct TcpPlugin;
 impl Plugin for TcpPlugin {
     fn build(&self, app: &mut App) {
 
+        static TCP_REQUEST_STAGE: &str = "tcp_request_stage";
+        static TCP_RESPONSE_STAGE: &str = "tcp_response_stage";
+
         match TcpListener::bind(URL) {
             Ok(listener) => {
-                app.add_state(TCPConnectionState::NotConnected)
-                .insert_resource(listener)
-                .insert_resource(TcpBuffer::new())
-                .add_system_set(
-                    SystemSet::on_update(TCPConnectionState::NotConnected)
-                        .with_system(Self::handle_incoming_system)
-                )
-                .add_system_set(
-                    SystemSet::on_update(TCPConnectionState::Connected)
-                        .with_system(Self::handle_requests_system)
-                );
+                app.add_loopless_state(TcpConnectionState::NotConnected)
+                    .insert_resource(listener)
+                    .insert_resource(TcpBuffer::new())
+
+                    .add_stage_before(CoreStage::First, TCP_REQUEST_STAGE, SystemStage::single_threaded())
+                    .add_stage_after(CoreStage::Last, TCP_RESPONSE_STAGE, SystemStage::single_threaded())
+
+                    .add_system_to_stage(
+                        TCP_REQUEST_STAGE,
+                        handle_incoming_connections.run_in_state(TcpConnectionState::NotConnected)
+                    )
+                    .add_system_to_stage(
+                        TCP_REQUEST_STAGE,
+                        request::handle_requests.run_in_state(TcpConnectionState::Connected)
+                    )
+                    .add_system_to_stage(
+                        TCP_RESPONSE_STAGE,
+                        response::handle_responses.run_in_state(TcpConnectionState::Connected)
+                    );
             },
             Err(e) => {
                 error!("{}", e)
@@ -70,144 +68,23 @@ impl Plugin for TcpPlugin {
     }
 }
 
-impl TcpPlugin {
+pub(crate) fn handle_incoming_connections(
+    mut commands: Commands,
+    listener: Res<TcpListener>
+) {
+    info!("Waiting for TCP connection...");
+    match listener.accept() {
+        Ok((stream, _)) => {
+            let ip = match stream.peer_addr() {
+                Ok(ip) => ip.ip().to_string(),
+                Err(_) => "Unknown".to_owned()
+            };
 
-    fn handle_incoming_system(
-        mut commands: Commands,
-        mut tcp_connection_state: ResMut<State<TCPConnectionState>>,
-        listener: Res<TcpListener>
-    ) {
-        info!("Waiting for TCP connection...");
-        match listener.accept() {
-            Ok((stream, _)) => {
-                info!("TCP connection established!");
-                commands.insert_resource(stream);
-                tcp_connection_state.set(TCPConnectionState::Connected).unwrap();
-            },
-            Err(e) => error!("{:?}", e)
-        }
-    }
+            info!("TCP connection established with {}!", ip);
 
-    fn handle_requests_system(
-        mut tcp_connection_state: ResMut<State<TCPConnectionState>>,
-        mut tcp_stream: ResMut<TcpStream>,
-        mut tcp_buffer: ResMut<TcpBuffer>,
-        mut system_event_writer: EventWriter<SystemEvent>,
-        mut spawn_event_writer: EventWriter<SpawnEvent>,
-        multibody_root_query: Query<(&MultibodyRoot, &Transform)>,
-        multibody_child_query: Query<(&MultiBodyChild, &Transform)>,
-        joint_query: Query<&Joint>
-    ) {
-        match tcp_stream.read(&mut tcp_buffer.data) {
-            Ok(msg_len) => {
-
-                let http_str = String::from_utf8_lossy(&tcp_buffer.data[..msg_len]).to_string();
-
-                match SimHttpRequest::from_http_str(http_str) {
-                    Ok(sim_req) => {
-
-                        if let Some(response_content) = Self::handle_request(
-                            sim_req, &mut system_event_writer, 
-                            &mut spawn_event_writer, 
-                            multibody_root_query,
-                            multibody_child_query,
-                            joint_query
-                        ) {
-
-                            // create response
-                            let response = format!(
-                                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\n\r\n{}",
-                                response_content.len(),
-                                response_content
-                            );
-
-                            // send response 
-                            tcp_stream.write(response.as_bytes()).unwrap();
-                            tcp_stream.flush().unwrap();
-                        }
-                    },
-                    Err(e) => error!("{}", e)
-                }
-            },
-            Err(e) => {
-                error!("Could not read tcp stream: {}", e);
-
-                // set state to not connected
-                if let Err(e) = tcp_connection_state.set(TCPConnectionState::NotConnected) {
-                    error!("{}", e);
-                }
-            }
-        }
-    }
-
-    fn handle_request(
-        mut req: SimHttpRequest, 
-        system_event_writer: &mut EventWriter<SystemEvent>,
-        spawn_event_writer: &mut EventWriter<SpawnEvent>,
-        multibody_root_query: Query<(&MultibodyRoot, &Transform)>,
-        multibody_child_query: Query<(&MultiBodyChild, &Transform)>,
-        joint_query: Query<&Joint>
-    ) -> Option<String> {
-
-        info!("Got Request: {:?}", req.actions);
-
-        let mut response = Response::new();
-
-        for action in req.actions.drain(..) {
-            match action {
-                SimAction::Close => { 
-                    system_event_writer.send(SystemEvent::Exit)
-                },
-                SimAction::SpawnModel { model, position: pos, color } => {
-                    spawn_event_writer.send(SpawnEvent::Spawn { model, transform: Transform::from_translation(pos), color })
-                }
-                SimAction::GetState => {
-
-                    let states = multibody_root_query.iter().map(|(root, transform)| {
-                        
-                        // get positions of all the child bodies
-                        let child_positions: HashMap<String, Vec3> = root.joint_name_2_entity.iter().map(|(name, entity)| {
-                            let position = match multibody_child_query.get(*entity) {
-                                Ok((_, transform)) => transform.translation,
-                                Err(_) => Vec3::ZERO
-                            };
-                            (name.clone(), position)
-                        }).collect();
-
-                        // Get joint angles
-                        let joint_states: HashMap<String, Option<JointState>> = root.joint_name_2_entity.iter().map(|(name, e)| {
-                            let orientation = match joint_query.get(*e) {
-                                Ok(joint) => {
-                                    Some(joint.get_state())
-                                }
-                                Err(_) => None
-                            };
-                            (name.clone(), orientation)
-                        }).collect();
-
-                        MultiBodyState {
-                            name: root.name.clone(),
-                            global_position: transform.translation,
-                            global_orientation: transform.rotation.to_euler(EulerRot::XYZ).into(),
-                            global_angular_velocity: root.angvel,
-                            relative_positions: Some(child_positions),
-                            joint_states: Some(joint_states)
-                        }
-
-                    }).collect::<Vec<MultiBodyState>>();
-                    response.multibody_states = Some(states);
-                },
-                SimAction::PausePhysics => {
-                    system_event_writer.send(SystemEvent::PausePhysics)
-                },
-                SimAction::RunPhysics => {
-                    system_event_writer.send(SystemEvent::RunPhysics)
-                }
-                _ => {}
-            }
-        }
-
-        Some(serde_json::to_string_pretty(&response).unwrap())
+            commands.insert_resource(NextState(TcpConnectionState::Connected));
+            commands.insert_resource(stream);
+        },
+        Err(e) => error!("{}", e)
     }
 }
-

--- a/crates/kesko_tcp/src/request.rs
+++ b/crates/kesko_tcp/src/request.rs
@@ -1,12 +1,30 @@
-use bevy::prelude::*;
+use std::net::TcpStream;
+use std::io::Read;
+
+use bevy::{
+    prelude::*, 
+    utils::hashbrown::HashMap
+};
+use iyes_loopless::prelude::*;
 use serde::{Serialize, Deserialize};
 
-use kesko_models::Model;
+use kesko_core::event::{
+    SystemRequestEvent,
+    SystemResponseEvent
+};
+use kesko_models::{
+    Model, SpawnEvent
+};
+
+use super::{
+    TcpBuffer,
+    TcpConnectionState
+};
 
 
 
 #[derive(Deserialize, Serialize, Debug)]
-pub(crate) enum SimAction {
+pub(crate) enum TcpCommand {
     Close,
     GetState,
     Restart,
@@ -15,14 +33,19 @@ pub(crate) enum SimAction {
         position: Vec3,
         color: Color
     },
+    ApplyMotorCommand {
+        body_name: String,
+        command: HashMap<String, f32>
+    },
     PausePhysics,
     RunPhysics,
+    IsAlive,
     None
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct SimHttpRequest {
-    pub(crate) actions: Vec<SimAction>
+    pub(crate) actions: Vec<TcpCommand>
 }
 
 impl SimHttpRequest {
@@ -45,5 +68,58 @@ impl SimHttpRequest {
             }
             Err(e) => Err(format!("{}", e))
         }
+    }
+}
+
+pub(crate) fn handle_requests(
+    mut commands: Commands,
+    mut tcp_stream: ResMut<TcpStream>,
+    mut tcp_buffer: ResMut<TcpBuffer>,
+    mut system_event_writer: EventWriter<SystemRequestEvent>,
+    mut system_response_event_writer:  EventWriter<SystemResponseEvent>,
+    mut spawn_event_writer: EventWriter<SpawnEvent>,
+) {
+
+    let mut got_msg = false;
+    while !got_msg {
+        match tcp_stream.read(&mut tcp_buffer.data) {
+            Ok(msg_len) => {
+
+                if msg_len == 0 {
+                    continue;
+                }
+
+                got_msg = true;
+
+                let http_str = String::from_utf8_lossy(&tcp_buffer.data[..msg_len]).to_string();
+                match SimHttpRequest::from_http_str(http_str) {
+                    Ok(mut req) => {
+                        debug!("Got Request: {:?}", req.actions);
+
+                        for action in req.actions.drain(..) {
+                            match action {
+                                TcpCommand::Close => system_event_writer.send(SystemRequestEvent::ExitApp),
+                                TcpCommand::SpawnModel { model, position, color } => {
+                                    spawn_event_writer.send(SpawnEvent::Spawn { model, transform: Transform::from_translation(position), color });
+                                    system_response_event_writer.send(SystemResponseEvent::SpawnedModel);
+                                },
+                                TcpCommand::GetState => system_event_writer.send(SystemRequestEvent::GetState),
+                                TcpCommand::PausePhysics => system_event_writer.send(SystemRequestEvent::PausePhysics),
+                                TcpCommand::RunPhysics => system_event_writer.send(SystemRequestEvent::StartPhysics),
+                                TcpCommand::IsAlive => system_event_writer.send(SystemRequestEvent::IsAlive),
+                                TcpCommand::ApplyMotorCommand { body_name, command } => system_event_writer.send( SystemRequestEvent::ApplyMotorCommand { body_name, command }),
+                                _ => {}
+                            }
+                        }
+                    }
+                    Err(e) => error!("{}", e)
+                }
+            },
+            Err(e) => {
+                error!("Could not read tcp stream: {}", e);
+                commands.insert_resource(NextState(TcpConnectionState::NotConnected));
+            }
+        }
+
     }
 }

--- a/crates/kesko_tcp/src/response.rs
+++ b/crates/kesko_tcp/src/response.rs
@@ -1,17 +1,47 @@
-use serde::Serialize;
+use std::net::TcpStream;
+use std::io::Write;
 
-use kesko_physics::multibody::MultiBodyState;
+use bevy::prelude::*;
+
+use kesko_core::event::SystemResponseEvent;
 
 
-#[derive(Serialize)]
-#[serde(rename_all = "lowercase")]
-pub(crate) struct Response {
-    pub(crate) multibody_states: Option<Vec<MultiBodyState>>
-}
-impl Response {
-    pub(crate) fn new() -> Self {
-        Self {
-            multibody_states: None
+pub(crate) fn handle_responses(
+    mut tcp_stream: ResMut<TcpStream>,
+    mut response_events:  EventReader<SystemResponseEvent>
+) {
+
+    let mut responses: Vec<serde_traitobject::Box<dyn serde_traitobject::Any>> = Vec::new();
+
+    for event in response_events.iter() {
+        match event {
+            SystemResponseEvent::State(states) => {
+                responses.push(serde_traitobject::Box::new(states.clone()));
+            },
+            SystemResponseEvent::SpawnedModel => {
+                responses.push(serde_traitobject::Box::new("spawned model".to_owned()));
+            }
+            SystemResponseEvent::Alive => {
+                responses.push(serde_traitobject::Box::new("alive".to_owned()));
+            }
+            _ => {
+                responses.push(serde_traitobject::Box::new("OK".to_owned()));
+            }
+        }
+    }
+
+    if !responses.is_empty() {
+        if let Ok(json) = serde_json::to_string_pretty(&responses) {
+            // create http response
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\n\r\n{}",
+                json.len(),
+                json
+            );
+
+            // send response 
+            tcp_stream.write(response.as_bytes()).unwrap();
+            tcp_stream.flush().unwrap();
         }
     }
 }


### PR DESCRIPTION
In order to answer a tcp request in one cycle the request and response system are divided into to systems that are in separate stages. The request stage is run before anything else and the response system is the last system that runs in order to assure that all data is available and updated. Much polish to do however.

Also the requests goes through SystemEvents which is meant to be the API into the simulator. Will see if this is a good idea or not but for now it makes things a bit cleaner.