### PR TITLE
Physics system refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 Cargo.lock
 
 # python
+**/__pycache__/**
 /venv
 
 # vscode
@@ -15,4 +16,6 @@ dist/
 # mac
 .DS_Store
 
-**/__pycache__/**
+
+# Ignore traces
+trace-*.json

--- a/crates/kesko_models/src/lib.rs
+++ b/crates/kesko_models/src/lib.rs
@@ -14,7 +14,7 @@ use serde::{Serialize, Deserialize};
 pub struct ModelPlugin;
 impl Plugin for ModelPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system_to_stage(CoreStage::PreUpdate, spawn_system);
+        app.add_system_to_stage(CoreStage::First, spawn_system);
     }
 }
 

--- a/crates/kesko_object_interaction/src/lib.rs
+++ b/crates/kesko_object_interaction/src/lib.rs
@@ -45,7 +45,7 @@ where T: Component + Default
             .init_resource::<GlobalDragState>()
             .add_plugin(RayCastPlugin::<T>::default())
             .add_system_set_to_stage(
-                CoreStage::First,
+                CoreStage::Update,
                 SystemSet::new()
                     .with_system(update_interactions::<T>
                         .label(InteractionSystems::UpdateInteractions)

--- a/crates/kesko_physics/src/collider.rs
+++ b/crates/kesko_physics/src/collider.rs
@@ -65,7 +65,7 @@ pub(crate) struct ColliderHandle(rapier::ColliderHandle);
 
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn add_collider_to_bodies_system(
+pub(crate) fn add_colliders(
     mut commands: Commands,
     mut entity_collider_map: ResMut<EntityColliderMap>,
     mut collider_set: ResMut<rapier::ColliderSet>,
@@ -137,8 +137,8 @@ mod tests {
 
     use bevy::prelude::*;
     use rapier3d::prelude as rapier;
-    use crate::collider::{EntityColliderMap, ColliderShape, ColliderPhysicalProperties, add_collider_to_bodies_system, ColliderHandle};
-    use crate::rigid_body::{RigidBody, Entity2BodyHandle, add_rigid_bodies_system, BodyHandle2Entity};
+    use crate::collider::{EntityColliderMap, ColliderShape, ColliderPhysicalProperties, add_colliders, ColliderHandle};
+    use crate::rigid_body::{RigidBody, Entity2BodyHandle, add_rigid_bodies, BodyHandle2Entity};
 
     fn setup_world() -> (World, SystemStage) {
 
@@ -151,8 +151,8 @@ mod tests {
         world.init_resource::<rapier::ColliderSet>();
 
         let test_stage = SystemStage::parallel()
-            .with_system(add_rigid_bodies_system)
-            .with_system(add_collider_to_bodies_system.after(add_rigid_bodies_system));
+            .with_system(add_rigid_bodies)
+            .with_system(add_colliders.after(add_rigid_bodies));
 
         (world, test_stage)
     }

--- a/crates/kesko_physics/src/joint.rs
+++ b/crates/kesko_physics/src/joint.rs
@@ -166,7 +166,7 @@ pub struct MultibodyJointHandle(pub(crate) rapier::MultibodyJointHandle);
 
 /// System to add multibody joints between bodies
 #[allow(clippy::type_complexity)]
-pub(crate) fn add_multibody_joints_system(
+pub(crate) fn add_multibody_joints(
     mut commands: Commands,
     mut multibody_joint_set: ResMut<rapier::MultibodyJointSet>,
     entity_body_map: Res<Entity2BodyHandle>,
@@ -324,7 +324,7 @@ mod tests {
 
         let mut world = World::default();
         let mut test_stage = SystemStage::parallel();
-        test_stage.add_system(add_multibody_joints_system);
+        test_stage.add_system(add_multibody_joints);
 
         world.init_resource::<rapier3d::prelude::MultibodyJointSet>();
 

--- a/crates/kesko_physics/src/lib.rs
+++ b/crates/kesko_physics/src/lib.rs
@@ -29,28 +29,18 @@ pub enum PhysicState {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, StageLabel)]
 struct PhysicsStage;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemLabel)]
-pub enum PhysicsSystem {
+#[derive(Debug, PartialEq, Eq, Clone, Hash, StageLabel)]
+pub enum PhysicStage {
 
     AddRigidBodies,
     AddJoints,
     AddColliders,
     AddMultibodies,
 
-    UpdateMultibodyVelAngVel,
-    UpdateImpulse,
-    UpdateForce,
-    UpdateGravityScale,
-    UpdateMultibodyMass,
-    UpdateJointMotors,
-    
-    PrePipelineSet,
     PipelineStep,
-    PostPipelineSet,
 
-    SendCollisionEvents,
-    
-    UpdateBevyWorld,
+    PostPipeline
+
 }
 
 pub struct PhysicsPlugin {
@@ -113,32 +103,32 @@ impl Plugin for PhysicsPlugin {
 
             .add_event::<joint::JointMotorEvent>()
 
-            .add_stage_before(CoreStage::First, PhysicsStage, Schedule::default())
+            .add_stage_after(CoreStage::First, PhysicsStage, Schedule::default())
             .stage(PhysicsStage, |stage: &mut Schedule| {
                 stage
                 .add_stage(
-                    "add-rigid-bodies", 
+                    PhysicStage::AddRigidBodies, 
                     SystemStage::single_threaded()
-                        .with_system(rigid_body::add_rigid_bodies_system)
+                        .with_system(rigid_body::add_rigid_bodies)
                 )
                 .add_stage(
-                    "add-colliders", 
+                    PhysicStage::AddColliders, 
                     SystemStage::single_threaded()
-                        .with_system(collider::add_collider_to_bodies_system)
+                        .with_system(collider::add_colliders)
+                )
+                .add_stage(
+                    PhysicStage::AddJoints, 
+                    SystemStage::single_threaded()
+                        .with_system(joint::add_multibody_joints)
                 )
                 .add_stage(
                     "add-multibodies", 
                     SystemStage::single_threaded()
-                    .with_system(multibody::add_multibody_components_system)
+                    .with_system(multibody::add_multibodies)
                 )
                 .add_stage(
                     "pipeline-step", 
                     SystemStage::single_threaded().with_system(physics_pipeline_step.run_in_state(PhysicState::Running))
-                )
-                .add_stage(
-                    "add-joints", 
-                    SystemStage::single_threaded()
-                        .with_system(joint::add_multibody_joints_system)
                 )
                 .add_stage(
                     "post-pipeline", 
@@ -159,57 +149,6 @@ impl Plugin for PhysicsPlugin {
                     )
                 )
             });
-
-            // .add_system_set_to_stage(
-            //     CoreStage::Update, 
-            //     SystemSet::new()
-            //         .label(PhysicsSystem::PrePipelineSet)
-            //         .with_system(
-            //             rigid_body::add_rigid_bodies_system
-            //             .label(PhysicsSystem::AddRigidBodies)
-            //         )
-            //         .with_system(
-            //             joint::add_multibody_joints_system
-            //                 .label(PhysicsSystem::AddJoints)
-            //                 .after(PhysicsSystem::AddRigidBodies)
-            //         )
-            //         .with_system(
-            //             collider::add_collider_to_bodies_system
-            //                 .label(PhysicsSystem::AddColliders)
-            //                 .after(PhysicsSystem::AddRigidBodies))
-            //         .with_system(
-            //             multibody::add_multibody_components_system 
-            //                 .label(PhysicsSystem::AddMultibodies)
-            //                 .after(PhysicsSystem::AddJoints))
-            // )
-
-            // .add_system_to_stage(
-            //     CoreStage::Update, 
-            //     physics_pipeline_step
-            //         .run_in_state(PhysicState::Running)
-            //         .label(PhysicsSystem::PipelineStep)
-            //         .after(PhysicsSystem::PrePipelineSet)
-            // )
-            
-            // .add_system_set_to_stage(
-            //     CoreStage::Update, 
-            //     ConditionSet::new()
-            //         .run_in_state(PhysicState::Running)
-            //         .label(PhysicsSystem::PostPipelineSet)
-            //         .after(PhysicsSystem::PipelineStep)
-
-            //         .with_system(update_bevy_world)
-            //         .with_system(multibody::update_multibody_vel_angvel)
-            //         .with_system(impulse::update_impulse)
-            //         .with_system(force::update_force_system)
-            //         .with_system(gravity::update_gravity_scale_system)
-            //         .with_system(mass::update_multibody_mass_system)
-            //         .with_system(joint::update_joint_motors_system)
-            //         .with_system(joint::update_joint_pos_system)
-            //         .with_system(send_collision_events_system)
-            //         .into()
-            // );
-
     }
 }
 

--- a/crates/kesko_physics/src/multibody.rs
+++ b/crates/kesko_physics/src/multibody.rs
@@ -83,7 +83,7 @@ impl MultibodyNameRegistry {
 /// 
 /// Todo: Look how to improve this, now it feels a bit complicated and not clear.
 #[allow(clippy::type_complexity)]
-pub(crate) fn add_multibody_components_system(
+pub(crate) fn add_multibodies(
     mut commands: Commands,
     mut name_registry: ResMut<MultibodyNameRegistry>,
     multibody_joint_set: Res<rapier::MultibodyJointSet>,

--- a/crates/kesko_physics/src/rigid_body.rs
+++ b/crates/kesko_physics/src/rigid_body.rs
@@ -31,7 +31,7 @@ pub struct RigidBodyHandle(pub rapier::RigidBodyHandle);
 
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn add_rigid_bodies_system(
+pub(crate) fn add_rigid_bodies(
     mut rigid_body_set: ResMut<rapier::RigidBodySet>,
     mut entity_2_body: ResMut<Entity2BodyHandle>,
     mut body_2_entity: ResMut<BodyHandle2Entity>,
@@ -83,7 +83,7 @@ mod tests {
 
     use bevy::prelude::*;
     use rapier3d::prelude as rapier;
-    use crate::rigid_body::{add_rigid_bodies_system, Entity2BodyHandle, RigidBody, RigidBodyHandle, BodyHandle2Entity};
+    use crate::rigid_body::{add_rigid_bodies, Entity2BodyHandle, RigidBody, RigidBodyHandle, BodyHandle2Entity};
     use crate::conversions::IntoBevy;
 
     #[test]
@@ -92,7 +92,7 @@ mod tests {
         let mut world = World::default();
 
         let mut test_stage = SystemStage::parallel();
-        test_stage.add_system(add_rigid_bodies_system);
+        test_stage.add_system(add_rigid_bodies);
 
         world.init_resource::<Entity2BodyHandle>();
         world.init_resource::<BodyHandle2Entity>();

--- a/crates/kesko_raycast/src/lib.rs
+++ b/crates/kesko_raycast/src/lib.rs
@@ -51,7 +51,7 @@ where T: Component + Default
     fn build(&self, app: &mut App) {
 
         app.add_system_set_to_stage(
-            CoreStage::First,
+            CoreStage::Update,
             SystemSet::new()
                 .with_system(create_rays_system::<T>
                     .label(RayCastSystems::CreateRays))

--- a/examples/joints.rs
+++ b/examples/joints.rs
@@ -27,7 +27,6 @@ use kesko_plugins::CorePlugins;
 fn main() {
     App::new()
     .add_plugins(CorePlugins)
-    .add_system(debug)
     .add_startup_system(setup_scene)
     .run();
 }
@@ -324,13 +323,4 @@ fn build_test_bench(
     .id();
 
     (bench, world_transform)
-}
-
-fn debug(
-    commands: Commands,
-    query: Query<(&RigidBodyName, &Transform)>
-) {
-    for (name, transform) in query.iter() {
-        println!("{}: {}", name.0, transform.translation);
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,14 +48,14 @@ fn test_scene(
         &mut commands,
         materials.add(Color::SEA_GREEN.into()), 
         materials.add(Color::DARK_GRAY.into()), 
-        Transform::from_xyz(0.0, 2.0, 0.0),
+        Transform::from_xyz(0.0, 1.0, -2.0),
         &mut meshes,
     );
 
     kesko_models::spider::spawn(
         &mut commands,
         materials.add(Color::CRIMSON.into()), 
-        Transform::from_xyz(2.0, 2.0, 0.0),
+        Transform::from_xyz(2.0, 1.0, 0.0),
         &mut meshes,
     );
 
@@ -63,7 +63,7 @@ fn test_scene(
         &mut commands,
         materials.add(Color::FUCHSIA.into()), 
         materials.add(Color::DARK_GRAY.into()), 
-        Transform::from_xyz(-2.0, 2.0, 0.0),
+        Transform::from_xyz(-2.0, 1.0, 0.0),
         &mut meshes,
     );
 


### PR DESCRIPTION
physics system was not run in the way intended. Since the system right now depends on commands and components
they need to be run in separate stages since it is only across stages that commands are executed. The physics systems
now have a separate stage that comes after CoreStage::First. This stage contains sub stages that executes the physics systems.
In this way all the physics systems should be updated during one frame.