### PR TITLE
add f64/f32 features to kesko_physics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ codegen-units = 1
 
 [dependencies]
 bevy = { version = "0.8.1" }
-kesko_physics = { version = "0.1.0", path = "crates/kesko_physics" }
+kesko_physics = { version = "0.1.0", path = "crates/kesko_physics", features = ["f64"]}
 kesko_core = { version = "0.1.0", path = "crates/kesko_core" }
 kesko_object_interaction = { version = "0.1.0", path = "crates/kesko_object_interaction"}
 kesko_raycast = { version = "0.1.0", path = "crates/kesko_raycast"}

--- a/crates/kesko_core/src/cursor_tracking.rs
+++ b/crates/kesko_core/src/cursor_tracking.rs
@@ -97,9 +97,9 @@ pub(crate) fn update_tracking_controller_system<T: Component + Default>(
                 let mut control_output = track.controller.act(pos_diff);
 
                 if let Some(mass) = multibody_mass {
-                    control_output *= mass.val;
+                    control_output *= mass.val as f32;
                 } else {
-                    control_output *= mass.val;
+                    control_output *= mass.val as f32;
                 }
 
                 force.vec = control_output;

--- a/crates/kesko_core/src/event.rs
+++ b/crates/kesko_core/src/event.rs
@@ -14,7 +14,8 @@ use kesko_physics::{
     joint::{
         JointState,
         JointMotorEvent, MotorCommand, revolute::RevoluteJoint, prismatic::PrismaticJoint,
-    }
+    },
+    rapier_extern::rapier::prelude as rapier
 };
 
 
@@ -68,7 +69,7 @@ pub fn handle_motor_command_requests(
                         if let Some(e) = root.child_map.get(joint_name) {
                             motor_event_writer.send(JointMotorEvent {
                                 entity: *e,
-                                action: MotorCommand::PositionRevolute { position: *val, stiffness: None, damping: None}
+                                action: MotorCommand::PositionRevolute { position: *val as rapier::Real, stiffness: None, damping: None}
                             });
                         }
                     }

--- a/crates/kesko_core/src/shape.rs
+++ b/crates/kesko_core/src/shape.rs
@@ -3,6 +3,7 @@ use bevy::render::mesh::{PrimitiveTopology, Indices, Mesh, shape};
 use bevy::math::Vec3;
 
 use kesko_physics::collider::ColliderShape;
+use kesko_physics::rapier_extern::rapier::prelude as rapier;
 
 
 /// A cylinder which stands on the XZ plane
@@ -177,19 +178,19 @@ impl Shape {
     pub fn into_collider_shape(&self) -> ColliderShape {
         match self {
             Self::Sphere { radius , subdivisions: _} => {
-                ColliderShape::Sphere { radius: *radius }
+                ColliderShape::Sphere { radius: *radius as rapier::Real}
             },
             Self::Box { x_length, y_length, z_length } => {
-                ColliderShape::Cuboid { x_half: x_length / 2.0, y_half: y_length / 2.0, z_half: z_length / 2.0 }
+                ColliderShape::Cuboid { x_half: (x_length / 2.0) as rapier::Real, y_half: (y_length / 2.0) as rapier::Real, z_half: (z_length / 2.0) as rapier::Real }
             },
             Self::Cylinder { radius, length, resolution: _} => {
-                ColliderShape::Cylinder { radius: *radius, length: *length }
+                ColliderShape::Cylinder { radius: *radius as rapier::Real, length: *length as rapier::Real}
             },
             Self::Capsule { radius, length } => {
-                ColliderShape::CapsuleY { half_length: length / 2.0, radius: *radius }
+                ColliderShape::CapsuleY { half_length: (length / 2.0) as rapier::Real, radius: *radius as rapier::Real}
             },
             Self::Cube { size } => {
-                ColliderShape::Cuboid { x_half: size / 2.0, y_half: size / 2.0, z_half: size / 2.0 }
+                ColliderShape::Cuboid { x_half: (size / 2.0) as rapier::Real, y_half: (size / 2.0) as rapier::Real, z_half: (size / 2.0) as rapier::Real}
             }
         } 
     }

--- a/crates/kesko_models/src/car.rs
+++ b/crates/kesko_models/src/car.rs
@@ -13,7 +13,8 @@ use kesko_physics::{
         revolute::RevoluteJoint,
         JointMotorEvent, MotorCommand
     },
-    multibody::MultibodyRoot, mass::Mass
+    multibody::MultibodyRoot, mass::Mass,
+    rapier_extern::rapier::prelude as rapier
 };
 use kesko_object_interaction::InteractiveBundle;
 use kesko_core::{
@@ -422,15 +423,15 @@ impl Car {
 /// Should hold the settings for sensitivity etc
 #[derive(Component)]
 struct CarController {
-    max_velocity: f32,      // m/s
-    max_turn_angle: f32,    // rad
+    max_velocity: rapier::Real,      // m/s
+    max_turn_angle: rapier::Real,    // rad
 }
 
 impl Default for CarController {
     fn default() -> Self {
        Self {
             max_velocity: 12.0,
-            max_turn_angle: FRAC_PI_6,
+            max_turn_angle: FRAC_PI_6 as rapier::Real,
        } 
     }
 }

--- a/crates/kesko_models/src/humanoid.rs
+++ b/crates/kesko_models/src/humanoid.rs
@@ -12,7 +12,8 @@ use kesko_physics::{
         revolute::RevoluteJoint, 
         fixed::FixedJoint
     }, 
-    mass::Mass
+    mass::Mass,
+    rapier_extern::rapier::prelude as rapier
 };
 use kesko_object_interaction::InteractiveBundle;
 use kesko_core::{
@@ -29,10 +30,10 @@ use super::Model;
 
 // For some reason we need to set the mass of the bodies, otherwise it behaves like there is almost
 // no gravity, seems like a bug in Rapier. For now use the same mass for all bodies
-const MASS: f32 = 0.1;
+const MASS: rapier::Real = 0.1;
 
-const STIFFNESS: f32 = 1.0;
-const DAMPING: f32 = 0.3;
+const STIFFNESS: rapier::Real = 1.0;
+const DAMPING: rapier::Real = 0.3;
 
 const HEAD_RADIUS: f32 = 0.13;
 const NECK_LENGTH: f32 = 0.13;

--- a/crates/kesko_physics/Cargo.toml
+++ b/crates/kesko_physics/Cargo.toml
@@ -3,10 +3,16 @@ name = "kesko_physics"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["f64"]
+f64 = ["dep:rapier3d-f64"]
+f32 = ["dep:rapier3d"]
+
 [dependencies]
 bevy = "0.8.1"
 iyes_loopless = { git = "https://github.com/IyesGames/iyes_loopless.git", branch = "main"}
-rapier3d = { git = "https://github.com/wynss/rapier.git" }
+rapier3d-f64 = { git = "https://github.com/wynss/rapier.git", optional = true }
+rapier3d = { git = "https://github.com/wynss/rapier.git", optional = true }
 nalgebra = "0.31.0"
 fnv = "1.0.7"
 crossbeam = "0.8.1"
@@ -14,5 +20,5 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_traitobject = "0.2.7"
 
-[profile.dev.package.rapier3d]
+[profile.dev.package.rapier3d_f64]
 opt-level = 3

--- a/crates/kesko_physics/src/collider.rs
+++ b/crates/kesko_physics/src/collider.rs
@@ -108,9 +108,9 @@ pub(crate) fn add_colliders(
  
         if let Some(physical_props) = physical_props {
             collider_builder = collider_builder
-            .density(physical_props.density as f64)
-            .friction(physical_props.friction as f64)
-            .restitution(physical_props.restitution as f64);
+            .density(physical_props.density)
+            .friction(physical_props.friction)
+            .restitution(physical_props.restitution);
         }
 
         if gen_events.is_some() {
@@ -229,8 +229,8 @@ mod tests {
         let collider_set = world.get_resource::<rapier::ColliderSet>().unwrap();
         let collider = collider_set.get(collider_handle.0).unwrap();
 
-        assert_eq!(collider.density(), physical_properties.density as f64);
-        assert_eq!(collider.friction(), physical_properties.friction as f64);
-        assert_eq!(collider.restitution(), physical_properties.restitution as f64);
+        assert_eq!(collider.density(), physical_properties.density);
+        assert_eq!(collider.friction(), physical_properties.friction);
+        assert_eq!(collider.restitution(), physical_properties.restitution);
     }
 }

--- a/crates/kesko_physics/src/collider.rs
+++ b/crates/kesko_physics/src/collider.rs
@@ -1,9 +1,9 @@
 use bevy::prelude::*;
-use rapier3d::prelude as rapier;
+use crate::rapier_extern::rapier::prelude as rapier;
 use fnv::FnvHashMap;
 
-use super::rigid_body::RigidBodyHandle;
 use crate::{
+    rigid_body::RigidBodyHandle,
     mass::Mass, 
     event::collision::GenerateCollisionEvents
 };
@@ -14,28 +14,28 @@ pub type Entity2ColliderHandle = FnvHashMap<Entity, rapier::ColliderHandle>;
 #[derive(Component)]
 pub enum ColliderShape {
     Cuboid {
-        x_half: f32,
-        y_half: f32,
-        z_half: f32
+        x_half: rapier::Real,
+        y_half: rapier::Real,
+        z_half: rapier::Real
     },
     Sphere {
-        radius: f32
+        radius: rapier::Real
     },
     CapsuleX {
-        half_length: f32,
-        radius: f32
+        half_length: rapier::Real,
+        radius: rapier::Real
     },
     CapsuleY {
-        half_length: f32,
-        radius: f32
+        half_length: rapier::Real,
+        radius: rapier::Real
     },
     CapsuleZ {
-        half_length: f32,
-        radius: f32
+        half_length: rapier::Real,
+        radius: rapier::Real
     },
     Cylinder {
-        radius: f32,
-        length: f32
+        radius: rapier::Real,
+        length: rapier::Real
     }
 }
 
@@ -43,11 +43,11 @@ pub enum ColliderShape {
 #[derive(Component, Debug, Clone)]
 pub struct ColliderPhysicalProperties {
     /// density of the collider
-    pub density: f32,
+    pub density: rapier::Real,
     /// friction coefficient of the collider
-    pub friction: f32,
+    pub friction: rapier::Real,
     /// restitution coefficient, controls how elastic or bouncy the collider is
-    pub restitution: f32
+    pub restitution: rapier::Real
 }
 
 impl Default for ColliderPhysicalProperties {
@@ -108,9 +108,9 @@ pub(crate) fn add_colliders(
  
         if let Some(physical_props) = physical_props {
             collider_builder = collider_builder
-            .density(physical_props.density)
-            .friction(physical_props.friction)
-            .restitution(physical_props.restitution);
+            .density(physical_props.density as f64)
+            .friction(physical_props.friction as f64)
+            .restitution(physical_props.restitution as f64);
         }
 
         if gen_events.is_some() {
@@ -141,7 +141,7 @@ pub(crate) fn add_colliders(
 mod tests {
 
     use bevy::prelude::*;
-    use rapier3d::prelude as rapier;
+    use crate::rapier_extern::rapier::prelude as rapier;
     use crate::collider::{Entity2ColliderHandle, ColliderShape, ColliderPhysicalProperties, add_colliders, ColliderHandle};
     use crate::rigid_body::{RigidBody, Entity2BodyHandle, add_rigid_bodies, BodyHandle2Entity};
 
@@ -229,8 +229,8 @@ mod tests {
         let collider_set = world.get_resource::<rapier::ColliderSet>().unwrap();
         let collider = collider_set.get(collider_handle.0).unwrap();
 
-        assert_eq!(collider.density(), physical_properties.density);
-        assert_eq!(collider.friction(), physical_properties.friction);
-        assert_eq!(collider.restitution(), physical_properties.restitution);
+        assert_eq!(collider.density(), physical_properties.density as f64);
+        assert_eq!(collider.friction(), physical_properties.friction as f64);
+        assert_eq!(collider.restitution(), physical_properties.restitution as f64);
     }
 }

--- a/crates/kesko_physics/src/conversions.rs
+++ b/crates/kesko_physics/src/conversions.rs
@@ -1,8 +1,12 @@
 use bevy::math::{Vec3, Quat};
 use bevy::prelude::Transform;
-use rapier3d::prelude::UnitVector;
-use rapier3d::math::{Translation, Isometry, Vector};
 use nalgebra::{UnitQuaternion, Vector3, Quaternion, Point3, UnitVector3};
+
+use crate::rapier_extern::rapier::{
+    math::{
+        Translation, Isometry, Vector, Real, UnitVector
+    }
+};
 
 
 pub trait IntoBevy<T> {
@@ -10,34 +14,34 @@ pub trait IntoBevy<T> {
     fn into_bevy(self) -> T;
 }
 
-impl IntoBevy<Vec3> for Vector3<f32> {
+impl IntoBevy<Vec3> for Vector3<Real> {
     fn into_bevy(self) -> Vec3 {
-        Vec3::new(self.x, self.y, self.z)
+        Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 }
 
 
-impl IntoBevy<Vec3> for Translation<f32> {
+impl IntoBevy<Vec3> for Translation<Real> {
     fn into_bevy(self) -> Vec3 {
        self.vector.into_bevy()
     }
 }
 
-impl IntoBevy<Quat> for UnitQuaternion<f32> {
+impl IntoBevy<Quat> for UnitQuaternion<Real> {
     fn into_bevy(self) -> Quat {
-        Quat::from_xyzw(self.i, self.j, self.k, self.w)
+        Quat::from_xyzw(self.i as f32, self.j as f32, self.k as f32, self.w as f32)
     }
 }
 
-impl IntoBevy<(Vec3, Quat)> for Isometry<f32> {
+impl IntoBevy<(Vec3, Quat)> for Isometry<Real> {
     fn into_bevy(self) -> (Vec3, Quat) {
         (self.translation.into_bevy(), self.rotation.into_bevy())
     }
 }
 
-impl IntoBevy<Vec3> for UnitVector<f32> {
+impl IntoBevy<Vec3> for UnitVector<Real> {
     fn into_bevy(self) -> Vec3 {
-        Vec3::new(self.x, self.y, self.y)
+        Vec3::new(self.x as f32, self.y as f32, self.y as f32)
     }
 }
 
@@ -46,44 +50,44 @@ pub trait IntoRapier<T> {
     fn into_rapier(self) -> T;
 }
 
-impl IntoRapier<Vector3<f32>> for Vec3 {
-    fn into_rapier(self) -> Vector3<f32> {
-        Vector3::new(self.x, self.y, self.z)
+impl IntoRapier<Vector3<Real>> for Vec3 {
+    fn into_rapier(self) -> Vector3<Real> {
+        Vector3::new(self.x as Real, self.y as Real, self.z as Real)
     }
 }
 
-impl IntoRapier<Point3<f32>> for Vec3 {
-    fn into_rapier(self) -> Point3<f32> {
-        Point3::from([self.x, self.y, self.z])
+impl IntoRapier<Point3<Real>> for Vec3 {
+    fn into_rapier(self) -> Point3<Real> {
+        Point3::from([self.x as Real, self.y as Real, self.z as Real])
     }
 }
 
-impl IntoRapier<UnitVector3<f32>> for Vec3 {
-    fn into_rapier(self) -> UnitVector3<f32> {
+impl IntoRapier<UnitVector3<Real>> for Vec3 {
+    fn into_rapier(self) -> UnitVector3<Real> {
         UnitVector3::new_normalize(self.into_rapier())
     }
 }
 
-impl IntoRapier<Translation<f32>> for Vec3 {
-    fn into_rapier(self) -> Translation<f32> {
-        <Vec3 as IntoRapier<Vector<f32>>>::into_rapier(self).into()
+impl IntoRapier<Translation<Real>> for Vec3 {
+    fn into_rapier(self) -> Translation<Real> {
+        <Vec3 as IntoRapier<Vector<Real>>>::into_rapier(self).into()
     }
 }
 
-impl IntoRapier<UnitQuaternion<f32>> for Quat {
-    fn into_rapier(self) -> UnitQuaternion<f32> {
-        UnitQuaternion::new_normalize(Quaternion::new(self.w, self.x, self.y, self.z))
+impl IntoRapier<UnitQuaternion<Real>> for Quat {
+    fn into_rapier(self) -> UnitQuaternion<Real> {
+        UnitQuaternion::new_normalize(Quaternion::new(self.w as Real, self.x as Real, self.y as Real, self.z as Real))
     }
 }
 
-impl IntoRapier<Isometry<f32>> for (Vec3, Quat) {
-    fn into_rapier(self) -> Isometry<f32> {
+impl IntoRapier<Isometry<Real>> for (Vec3, Quat) {
+    fn into_rapier(self) -> Isometry<Real> {
         Isometry::from_parts(self.0.into_rapier(), self.1.into_rapier())
     }
 }
 
-impl IntoRapier<Isometry<f32>> for Transform {
-    fn into_rapier(self) -> Isometry<f32> {
+impl IntoRapier<Isometry<Real>> for Transform {
+    fn into_rapier(self) -> Isometry<Real> {
         Isometry::from_parts(self.translation.into_rapier(), self.rotation.into_rapier())
     }
 }

--- a/crates/kesko_physics/src/event.rs
+++ b/crates/kesko_physics/src/event.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use iyes_loopless::prelude::*;
 use serde::{Serialize, Deserialize};
 
-use rapier3d::prelude as rapier;
+use crate::rapier_extern::rapier::prelude as rapier;
 
 use crate::{
     PhysicState,

--- a/crates/kesko_physics/src/event/collision.rs
+++ b/crates/kesko_physics/src/event/collision.rs
@@ -1,9 +1,5 @@
 use bevy::prelude::*;
-use rapier3d::{
-    geometry::CollisionEventFlags, 
-    pipeline::EventHandler
-};
-use rapier3d::prelude as rapier;
+use crate::rapier_extern::rapier;
 
 
 /// Component to indicate if an entity should generate collision events
@@ -24,24 +20,24 @@ pub enum CollisionEvent {
 pub struct CollisionData {
     pub entity1: Entity,
     pub entity2: Entity,
-    pub flag: CollisionEventFlags
+    pub flag: rapier::geometry::CollisionEventFlags
 }
 
 // Responsible for fetching collision events from Rapier and propagate them to Bevy
 pub(crate) struct CollisionEventHandler {
-    collision_send: crossbeam::channel::Sender<rapier3d::geometry::CollisionEvent>,
-    collision_recv: crossbeam::channel::Receiver<rapier3d::geometry::CollisionEvent>,
+    collision_send: crossbeam::channel::Sender<rapier::geometry::CollisionEvent>,
+    collision_recv: crossbeam::channel::Receiver<rapier::geometry::CollisionEvent>,
 }
 
-impl EventHandler for CollisionEventHandler {
+impl rapier::pipeline::EventHandler for CollisionEventHandler {
 
     /// fetches the collision events from rapier and sending them through the crossbeam
     fn handle_collision_event(
         &self,
-        _bodies: &rapier3d::prelude::RigidBodySet,
-        _colliders: &rapier3d::prelude::ColliderSet,
-        event: rapier3d::prelude::CollisionEvent,
-        _contact_pair: Option<&rapier3d::prelude::ContactPair>
+        _bodies: &rapier::dynamics::RigidBodySet,
+        _colliders: &rapier::geometry::ColliderSet,
+        event: rapier::geometry::CollisionEvent,
+        _contact_pair: Option<&rapier::geometry::ContactPair>
     ) {
         if let Err(e) = self.collision_send.send(event) {
             error!("Failed to propagate collision event: {e}");
@@ -50,11 +46,11 @@ impl EventHandler for CollisionEventHandler {
 
     fn handle_contact_force_event(
             &self,
-            _dt: rapier::Real,
-            _bodies: &rapier::RigidBodySet,
-            _colliders: &rapier::ColliderSet,
-            _contact_pair: &rapier::ContactPair,
-            _total_force_magnitude: rapier::Real,
+            _dt: rapier::math::Real,
+            _bodies: &rapier::dynamics::RigidBodySet,
+            _colliders: &rapier::geometry::ColliderSet,
+            _contact_pair: &rapier::geometry::ContactPair,
+            _total_force_magnitude: rapier::math::Real,
         ) {
         todo!("Implement when needed");
     }
@@ -67,12 +63,12 @@ impl CollisionEventHandler {
     }
 
     /// Propagate collision events from Rapier to Bevys event system
-    fn send_events(&self, event_writer: &mut EventWriter<CollisionEvent>, colliders: &rapier::ColliderSet) {
+    fn send_events(&self, event_writer: &mut EventWriter<CollisionEvent>, colliders: &rapier::geometry::ColliderSet) {
         
         while let Ok(event) = self.collision_recv.try_recv() {
 
             match event {
-                rapier::CollisionEvent::Started(handle1, handle2, flag) => {
+                rapier::geometry::CollisionEvent::Started(handle1, handle2, flag) => {
                     if let (Some(coll1), Some(coll2)) = (colliders.get(handle1), colliders.get(handle2)) {
                         event_writer.send(CollisionEvent::Started {
                             data: CollisionData {
@@ -83,7 +79,7 @@ impl CollisionEventHandler {
                         })
                     }
                 },
-                rapier::CollisionEvent::Stopped(handle1, handle2, flag) => {
+                rapier::geometry::CollisionEvent::Stopped(handle1, handle2, flag) => {
                     if let (Some(coll1), Some(coll2)) = (colliders.get(handle1), colliders.get(handle2)) {
                         event_writer.send(CollisionEvent::Stopped {
                             data: CollisionData {
@@ -103,7 +99,7 @@ impl CollisionEventHandler {
 /// System for propagating collision events to Bevy from Rapier
 /// Should be executed after the rapier pipeline step in order to capture the latest events
 pub(crate) fn send_collision_events_system(
-    colliders: Res<rapier::ColliderSet>,
+    colliders: Res<rapier::geometry::ColliderSet>,
     collision_event_manager: Res<CollisionEventHandler>,
     mut event_writer: EventWriter<CollisionEvent>
 ) {

--- a/crates/kesko_physics/src/force.rs
+++ b/crates/kesko_physics/src/force.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use rapier3d::prelude as rapier;
+use crate::rapier_extern::rapier::prelude as rapier;
 
 use crate::{rigid_body::RigidBodyHandle, conversions::IntoRapier};
 

--- a/crates/kesko_physics/src/gravity.rs
+++ b/crates/kesko_physics/src/gravity.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use crate::rapier_extern::rapier::dynamics::RigidBodySet;
+use crate::rapier_extern::rapier::prelude as rapier;
 use crate::rigid_body::RigidBodyHandle;
 
 
@@ -22,8 +22,8 @@ impl Default for Gravity {
 
 #[derive(Component)]
 pub struct GravityScale {
-    pub val: f64,
-    pub initial_val: f64
+    pub val: rapier::Real,
+    pub initial_val: rapier::Real
 }
 
 impl Default for GravityScale {
@@ -33,7 +33,7 @@ impl Default for GravityScale {
 }
 
 impl GravityScale {
-    pub fn new(val: f64) -> Self {
+    pub fn new(val: rapier::Real) -> Self {
         Self { val, initial_val: val }
     }
 
@@ -43,7 +43,7 @@ impl GravityScale {
 }
 
 pub(crate) fn update_gravity_scale_system(
-    mut rigid_bodies: ResMut<RigidBodySet>,
+    mut rigid_bodies: ResMut<rapier::RigidBodySet>,
     query: Query<(&RigidBodyHandle, &GravityScale), Changed<GravityScale>>
 ) {
     for (body_handle, gravity_scale) in query.iter() {

--- a/crates/kesko_physics/src/gravity.rs
+++ b/crates/kesko_physics/src/gravity.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use rapier3d::dynamics::RigidBodySet;
+use crate::rapier_extern::rapier::dynamics::RigidBodySet;
 use crate::rigid_body::RigidBodyHandle;
 
 
@@ -22,8 +22,8 @@ impl Default for Gravity {
 
 #[derive(Component)]
 pub struct GravityScale {
-    pub val: f32,
-    pub initial_val: f32
+    pub val: f64,
+    pub initial_val: f64
 }
 
 impl Default for GravityScale {
@@ -33,7 +33,7 @@ impl Default for GravityScale {
 }
 
 impl GravityScale {
-    pub fn new(val: f32) -> Self {
+    pub fn new(val: f64) -> Self {
         Self { val, initial_val: val }
     }
 

--- a/crates/kesko_physics/src/impulse.rs
+++ b/crates/kesko_physics/src/impulse.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use rapier3d::prelude as rapier;
+use crate::rapier_extern::rapier::prelude as rapier;
 use crate::rigid_body::RigidBodyHandle;
 use crate::conversions::IntoRapier;
 

--- a/crates/kesko_physics/src/joint.rs
+++ b/crates/kesko_physics/src/joint.rs
@@ -17,6 +17,8 @@ use self::revolute::RevoluteJoint;
 
 pub type Entity2JointHandle = FnvHashMap<Entity, rapier::MultibodyJointHandle>;
 
+
+
 /// trait for converting an axis into a unit vector
 pub(crate) trait AxisIntoVec {
     fn into_unitvec(self) -> rapier::UnitVector<rapier::Real>;

--- a/crates/kesko_physics/src/joint.rs
+++ b/crates/kesko_physics/src/joint.rs
@@ -6,7 +6,7 @@ pub mod prismatic;
 use serde::{Serialize, Deserialize};
 use fnv::FnvHashMap;
 use bevy::prelude::*;
-use rapier3d::prelude as rapier;
+use crate::rapier_extern::rapier::prelude as rapier;
 
 use crate::rigid_body::{Entity2BodyHandle, RigidBodyHandle};
 use crate::conversions::IntoBevy;
@@ -67,11 +67,11 @@ pub enum KeskoAxis {
 pub enum JointState {
     Revolute { 
         axis: KeskoAxis,
-        angle: f32,
+        angle: rapier::Real,
     },
     Prismatic {
         axis: KeskoAxis,
-        position: f32
+        position: rapier::Real
     }
 }
 
@@ -174,39 +174,39 @@ pub struct JointMotorEvent {
 #[derive(Debug)]
 pub enum MotorCommand {
     PositionRevolute {
-        position: f32,
-        stiffness: Option<f32>,
-        damping: Option<f32>
+        position: rapier::Real,
+        stiffness: Option<rapier::Real>,
+        damping: Option<rapier::Real>
     },
     VelocityRevolute {
-        velocity: f32,
-        damping: Option<f32>
+        velocity: rapier::Real,
+        damping: Option<rapier::Real>
     },
     PositionSpherical {
-        position: f32,
+        position: rapier::Real,
         axis: KeskoAxis
     },
     VelocitySpherical {
-        velocity: f32,
+        velocity: rapier::Real,
         axis: KeskoAxis,
     },
     PositionPrismatic {
-        position: f32,
-        stiffness: Option<f32>,
-        damping: Option<f32>
+        position: rapier::Real,
+        stiffness: Option<rapier::Real>,
+        damping: Option<rapier::Real>
     },
     VelocityPrismatic {
-        velocity: f32,
-        damping: Option<f32>
+        velocity: rapier::Real,
+        damping: Option<rapier::Real>
     },
     SetStiffness {
-        val: f32
+        val: rapier::Real
     },
     SetDamping {
-        val: f32
+        val: rapier::Real
     },
     HoldPosition {
-        stiffness: Option<f32>
+        stiffness: Option<rapier::Real>
     }
 }
 
@@ -366,6 +366,8 @@ pub(crate) fn update_joint_motors_system(
 mod tests {
     use bevy::ecs::event::Events;
 
+    use crate::rapier_extern::rapier::prelude as rapier;
+
     use crate::joint::fixed::FixedJoint;
     use crate::conversions::IntoRapier;
     use super::*;
@@ -377,7 +379,7 @@ mod tests {
         let mut test_stage = SystemStage::parallel();
         test_stage.add_system(add_multibody_joints);
 
-        world.init_resource::<rapier3d::prelude::MultibodyJointSet>();
+        world.init_resource::<rapier::MultibodyJointSet>();
         world.init_resource::<Entity2JointHandle>();
 
         let parent_body_handle = rapier::RigidBodyHandle::from_raw_parts(1, 0);
@@ -408,7 +410,7 @@ mod tests {
         test_stage.run(&mut world);
 
         let multibody_joint_set = world
-            .get_resource::<rapier3d::prelude::MultibodyJointSet>()
+            .get_resource::<rapier::MultibodyJointSet>()
             .expect("Could not get ImpulseJointSet").clone();
 
         // only on element in set

--- a/crates/kesko_physics/src/joint/fixed.rs
+++ b/crates/kesko_physics/src/joint/fixed.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use rapier3d::prelude::{
+use crate::rapier_extern::rapier::prelude::{
     GenericJoint, 
     FixedJointBuilder
 };
@@ -47,8 +47,8 @@ impl From<FixedJoint> for GenericJoint {
 #[cfg(test)]
 mod tests {
     use bevy::prelude::{Transform, Vec3, Entity};
-    use rapier3d::prelude::GenericJoint;
-    use rapier3d::dynamics::JointAxis;
+    use crate::rapier_extern::rapier::prelude::GenericJoint;
+    use crate::rapier_extern::rapier::dynamics::JointAxis;
     use crate::IntoRapier;
     use super::FixedJoint;
 

--- a/crates/kesko_physics/src/joint/prismatic.rs
+++ b/crates/kesko_physics/src/joint/prismatic.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use rapier3d::prelude as rapier;
+use crate::rapier_extern::rapier::prelude as rapier;
 use crate::conversions::IntoRapier;
 
 use super::{AxisIntoVec, KeskoAxis, JointState};
@@ -12,11 +12,11 @@ pub struct PrismaticJoint {
     pub child_anchor: Transform,
     pub axis: KeskoAxis,
     pub limits: Option<Vec2>,
-    pub stiffness: f32,
-    pub damping: f32,
+    pub stiffness: rapier::Real,
+    pub damping: rapier::Real,
     pub max_motor_force: rapier::Real,
 
-    position: f32
+    position: rapier::Real
 }
 
 impl PrismaticJoint {
@@ -55,30 +55,30 @@ impl PrismaticJoint {
         self
     }
 
-    pub fn with_motor_params(mut self, stiffness: f32, damping: f32) -> Self {
+    pub fn with_motor_params(mut self, stiffness: rapier::Real, damping: rapier::Real) -> Self {
         self.stiffness = stiffness;
         self.damping = damping;
         self
     }
 
-    pub fn with_max_motor_force(mut self, max_motor_force: f32) -> Self {
+    pub fn with_max_motor_force(mut self, max_motor_force: rapier::Real) -> Self {
         self.max_motor_force = max_motor_force;
         self
     }
 
     pub fn update_position(&mut self, translation: Vec3) {
         match self.axis {
-            KeskoAxis::X => self.position = translation.x,
-            KeskoAxis::NegX => self.position = -translation.x,
-            KeskoAxis::Y => self.position = translation.y,
-            KeskoAxis::NegY => self.position = -translation.y,
-            KeskoAxis::Z => self.position = translation.z,
-            KeskoAxis::NegZ => self.position = -translation.z,
+            KeskoAxis::X => self.position = translation.x as rapier::Real,
+            KeskoAxis::NegX => self.position = -translation.x as rapier::Real,
+            KeskoAxis::Y => self.position = translation.y as rapier::Real,
+            KeskoAxis::NegY => self.position = -translation.y as rapier::Real,
+            KeskoAxis::Z => self.position = translation.z as rapier::Real,
+            KeskoAxis::NegZ => self.position = -translation.z as rapier::Real,
             _ => error!("Prismatic joint does not have a valid axis")
         }
     }
 
-    pub fn position(&self) -> f32 {
+    pub fn position(&self) -> rapier::Real {
         self.position
     }
 
@@ -94,12 +94,12 @@ impl From<PrismaticJoint> for rapier::GenericJoint {
             .local_anchor2(joint.child_anchor.translation.into_rapier());
         
         if joint.stiffness > 0.0 || joint.damping > 0.0 {
-            builder = builder.set_motor(0.0, 0.0, joint.stiffness, joint.damping).motor_max_force(joint.max_motor_force);
+            builder = builder.set_motor(0.0, 0.0, joint.stiffness as f64, joint.damping as f64).motor_max_force(joint.max_motor_force);
         }
 
-        if let Some(limits) = joint.limits {
-            builder = builder.limits(limits.into());
-        }
+        // if let Some(limits) = joint.limits {
+        //     builder = builder.limits(limits.into());
+        // }
 
         let mut generic: rapier::GenericJoint = builder.into();
         generic.local_frame1.rotation = joint.parent_anchor.rotation.into_rapier() * generic.local_frame1.rotation;
@@ -113,8 +113,8 @@ impl From<PrismaticJoint> for rapier::GenericJoint {
 mod tests {
     use bevy::math::Vec2;
     use bevy::prelude::{Transform, Vec3, Entity};
-    use rapier3d::dynamics::JointAxis;
-    use rapier3d::prelude::GenericJoint;
+    use crate::rapier_extern::rapier::dynamics::JointAxis;
+    use crate::rapier_extern::rapier::prelude::GenericJoint;
     use crate::{IntoRapier, joint::KeskoAxis};
     use super::PrismaticJoint;
 

--- a/crates/kesko_physics/src/joint/prismatic.rs
+++ b/crates/kesko_physics/src/joint/prismatic.rs
@@ -97,9 +97,9 @@ impl From<PrismaticJoint> for rapier::GenericJoint {
             builder = builder.set_motor(0.0, 0.0, joint.stiffness, joint.damping).motor_max_force(joint.max_motor_force);
         }
 
-        // if let Some(limits) = joint.limits {
-        //     builder = builder.limits(limits.into());
-        // }
+        if let Some(limits) = joint.limits {
+            builder = builder.limits([limits.x as rapier::Real, limits.y as rapier::Real]);
+        }
 
         let mut generic: rapier::GenericJoint = builder.into();
         generic.local_frame1.rotation = joint.parent_anchor.rotation.into_rapier() * generic.local_frame1.rotation;

--- a/crates/kesko_physics/src/joint/prismatic.rs
+++ b/crates/kesko_physics/src/joint/prismatic.rs
@@ -94,7 +94,7 @@ impl From<PrismaticJoint> for rapier::GenericJoint {
             .local_anchor2(joint.child_anchor.translation.into_rapier());
         
         if joint.stiffness > 0.0 || joint.damping > 0.0 {
-            builder = builder.set_motor(0.0, 0.0, joint.stiffness as f64, joint.damping as f64).motor_max_force(joint.max_motor_force);
+            builder = builder.set_motor(0.0, 0.0, joint.stiffness, joint.damping).motor_max_force(joint.max_motor_force);
         }
 
         // if let Some(limits) = joint.limits {

--- a/crates/kesko_physics/src/joint/revolute.rs
+++ b/crates/kesko_physics/src/joint/revolute.rs
@@ -105,9 +105,9 @@ impl From<RevoluteJoint> for rapier::GenericJoint {
 
         builder = builder.motor_max_force(joint.max_motor_force);
 
-        // if let Some(limits) = joint.limits {
-        //     builder = builder.limits(limits.into());
-        // }
+        if let Some(limits) = joint.limits {
+            builder = builder.limits([limits.x as rapier::Real, limits.y as rapier::Real]);
+        }
 
         let mut generic: rapier::GenericJoint = builder.into();
         generic.local_frame1.rotation = joint.parent_anchor.rotation.into_rapier() * generic.local_frame1.rotation;
@@ -119,9 +119,7 @@ impl From<RevoluteJoint> for rapier::GenericJoint {
 
 #[cfg(test)]
 mod tests {
-
-    use bevy::math::Vec2;
-    use bevy::prelude::{Transform, Vec3, Entity};
+    use bevy::prelude::{Transform, Vec3, Vec2, Entity};
     use crate::rapier_extern::rapier::dynamics::JointAxis;
     use crate::rapier_extern::rapier::prelude::GenericJoint;
     use crate::{IntoRapier, joint::KeskoAxis};

--- a/crates/kesko_physics/src/joint/revolute.rs
+++ b/crates/kesko_physics/src/joint/revolute.rs
@@ -61,8 +61,8 @@ impl RevoluteJoint {
         self
     }
 
-    pub fn with_max_motor_force(mut self, max_motor_force: f32) -> Self {
-        self.max_motor_force = max_motor_force as f64;
+    pub fn with_max_motor_force(mut self, max_motor_force: rapier::Real) -> Self {
+        self.max_motor_force = max_motor_force;
         self
     }
 
@@ -100,7 +100,7 @@ impl From<RevoluteJoint> for rapier::GenericJoint {
             .local_anchor2(joint.child_anchor.translation.into_rapier());
 
         if joint.stiffness > 0.0 || joint.damping > 0.0 {
-            builder = builder.motor(0.0, 0.0, joint.stiffness as f64, joint.damping as f64);
+            builder = builder.motor(0.0, 0.0, joint.stiffness, joint.damping);
         }
 
         builder = builder.motor_max_force(joint.max_motor_force);

--- a/crates/kesko_physics/src/joint/spherical.rs
+++ b/crates/kesko_physics/src/joint/spherical.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use rapier3d::prelude::{GenericJoint, JointAxis, SphericalJointBuilder};
+use crate::rapier_extern::rapier::prelude as rapier;
 
 use crate::conversions::IntoRapier;
 
@@ -12,12 +12,12 @@ pub struct SphericalJoint {
     pub x_ang_limit: Option<Vec2>,
     pub y_ang_limit: Option<Vec2>,
     pub z_ang_limit: Option<Vec2>,
-    pub x_stiffness: f32,
-    pub x_damping: f32,
-    pub y_stiffness: f32,
-    pub y_damping: f32,
-    pub z_stiffness: f32,
-    pub z_damping: f32,
+    pub x_stiffness: rapier::Real,
+    pub x_damping: rapier::Real,
+    pub y_stiffness: rapier::Real,
+    pub y_damping: rapier::Real,
+    pub z_stiffness: rapier::Real,
+    pub z_damping: rapier::Real,
 }
 
 impl SphericalJoint {
@@ -66,44 +66,44 @@ impl SphericalJoint {
     }
 }
 
-impl From<SphericalJoint> for GenericJoint {
-    fn from(joint: SphericalJoint) -> GenericJoint {
+impl From<SphericalJoint> for rapier::GenericJoint {
+    fn from(joint: SphericalJoint) -> rapier::GenericJoint {
 
-        let mut builder = SphericalJointBuilder::new();
+        let mut builder = rapier::SphericalJointBuilder::new();
 
         // set activate and set motor parameters
         if joint.x_stiffness > 0.0 || joint.x_damping > 0.0 {
-            builder = builder.motor(JointAxis::AngX, 0.0, 0.0,  joint.x_stiffness, joint.x_damping);
+            builder = builder.motor(rapier::JointAxis::AngX, 0.0, 0.0,  joint.x_stiffness as f64, joint.x_damping as f64);
         }
         if joint.y_stiffness > 0.0 || joint.y_damping > 0.0 {
-            builder = builder.motor(JointAxis::AngY, 0.0, 0.0,  joint.y_stiffness, joint.y_damping);
+            builder = builder.motor(rapier::JointAxis::AngY, 0.0, 0.0,  joint.y_stiffness as f64, joint.y_damping as f64);
         }
         if joint.z_stiffness > 0.0 || joint.z_damping > 0.0 {
-            builder = builder.motor(JointAxis::AngZ, 0.0, 0.0,  joint.z_stiffness, joint.z_damping);
+            builder = builder.motor(rapier::JointAxis::AngZ, 0.0, 0.0,  joint.z_stiffness as f64, joint.z_damping as f64);
         }
 
         // set rotational limits if any
-        if let Some(x_ang_limit) = joint.x_ang_limit {
-            builder = builder.limits(JointAxis::AngX, x_ang_limit.into());
-        }
+        // if let Some(x_ang_limit) = joint.x_ang_limit {
+        //     builder = builder.limits(JointAxis::AngX, x_ang_limit.into());
+        // }
 
-        if let Some(y_ang_limit) = joint.y_ang_limit {
-            builder = builder.limits(JointAxis::AngY, y_ang_limit.into());
-        }
+        // if let Some(y_ang_limit) = joint.y_ang_limit {
+        //     builder = builder.limits(JointAxis::AngY, y_ang_limit.into());
+        // }
 
-        if let Some(z_ang_limit) = joint.z_ang_limit {
-            builder = builder.limits(JointAxis::AngZ, z_ang_limit.into());
-        }
+        // if let Some(z_ang_limit) = joint.z_ang_limit {
+        //     builder = builder.limits(JointAxis::AngZ, z_ang_limit.into());
+        // }
 
-        let mut generic: GenericJoint = builder.into();
+        let mut generic: rapier::GenericJoint = builder.into();
         *generic
             .set_local_frame1(joint.parent_anchor.into_rapier())
             .set_local_frame2(joint.child_anchor.into_rapier())
     }
 }
 
-impl From<GenericJoint> for SphericalJoint {
-    fn from(_joint: GenericJoint) -> Self {
+impl From<rapier::GenericJoint> for SphericalJoint {
+    fn from(_joint: rapier::GenericJoint) -> Self {
         todo!("Implement this when we need to convert back to the specific joint");
     }
 }
@@ -112,8 +112,8 @@ impl From<GenericJoint> for SphericalJoint {
 mod tests {
     use bevy::math::Vec2;
     use bevy::prelude::{Transform, Vec3, Entity};
-    use rapier3d::dynamics::JointAxis;
-    use rapier3d::prelude::GenericJoint;
+    use crate::rapier_extern::rapier::dynamics::JointAxis;
+    use crate::rapier_extern::rapier::prelude::GenericJoint;
     use crate::IntoRapier;
     use super::SphericalJoint;
 

--- a/crates/kesko_physics/src/joint/spherical.rs
+++ b/crates/kesko_physics/src/joint/spherical.rs
@@ -73,13 +73,13 @@ impl From<SphericalJoint> for rapier::GenericJoint {
 
         // set activate and set motor parameters
         if joint.x_stiffness > 0.0 || joint.x_damping > 0.0 {
-            builder = builder.motor(rapier::JointAxis::AngX, 0.0, 0.0,  joint.x_stiffness as f64, joint.x_damping as f64);
+            builder = builder.motor(rapier::JointAxis::AngX, 0.0, 0.0,  joint.x_stiffness, joint.x_damping);
         }
         if joint.y_stiffness > 0.0 || joint.y_damping > 0.0 {
-            builder = builder.motor(rapier::JointAxis::AngY, 0.0, 0.0,  joint.y_stiffness as f64, joint.y_damping as f64);
+            builder = builder.motor(rapier::JointAxis::AngY, 0.0, 0.0,  joint.y_stiffness, joint.y_damping);
         }
         if joint.z_stiffness > 0.0 || joint.z_damping > 0.0 {
-            builder = builder.motor(rapier::JointAxis::AngZ, 0.0, 0.0,  joint.z_stiffness as f64, joint.z_damping as f64);
+            builder = builder.motor(rapier::JointAxis::AngZ, 0.0, 0.0,  joint.z_stiffness, joint.z_damping);
         }
 
         // set rotational limits if any

--- a/crates/kesko_physics/src/joint/spherical.rs
+++ b/crates/kesko_physics/src/joint/spherical.rs
@@ -83,17 +83,17 @@ impl From<SphericalJoint> for rapier::GenericJoint {
         }
 
         // set rotational limits if any
-        // if let Some(x_ang_limit) = joint.x_ang_limit {
-        //     builder = builder.limits(JointAxis::AngX, x_ang_limit.into());
-        // }
+        if let Some(x_ang_limit) = joint.x_ang_limit {
+            builder = builder.limits(rapier::JointAxis::AngX, [x_ang_limit.x as rapier::Real, x_ang_limit.y as rapier::Real]);
+        }
 
-        // if let Some(y_ang_limit) = joint.y_ang_limit {
-        //     builder = builder.limits(JointAxis::AngY, y_ang_limit.into());
-        // }
+        if let Some(y_ang_limit) = joint.y_ang_limit {
+            builder = builder.limits(rapier::JointAxis::AngY, [y_ang_limit.x as rapier::Real, y_ang_limit.y as rapier::Real]);
+        }
 
-        // if let Some(z_ang_limit) = joint.z_ang_limit {
-        //     builder = builder.limits(JointAxis::AngZ, z_ang_limit.into());
-        // }
+        if let Some(z_ang_limit) = joint.z_ang_limit {
+            builder = builder.limits(rapier::JointAxis::AngZ, [z_ang_limit.x as rapier::Real, z_ang_limit.y as rapier::Real]);
+        }
 
         let mut generic: rapier::GenericJoint = builder.into();
         *generic

--- a/crates/kesko_physics/src/lib.rs
+++ b/crates/kesko_physics/src/lib.rs
@@ -8,11 +8,12 @@ pub mod joint;
 pub mod event;
 pub mod multibody;
 mod conversions;
+pub mod rapier_extern;
 
 use bevy::prelude::*;
 use bevy::math::Vec3;
 use iyes_loopless::prelude::*;
-use rapier3d::prelude as rapier;
+use self::rapier_extern::rapier::prelude as rapier;
 
 use conversions::{IntoRapier, IntoBevy};
 use gravity::Gravity;

--- a/crates/kesko_physics/src/mass.rs
+++ b/crates/kesko_physics/src/mass.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use rapier3d::prelude as rapier;
+use crate::rapier_extern::rapier::prelude as rapier;
 
 use crate::rigid_body::RigidBodyHandle;
 
@@ -7,14 +7,14 @@ use crate::rigid_body::RigidBodyHandle;
 /// Component for storing the mass of a rigid body
 #[derive(Component)]
 pub struct Mass {
-    pub val: f32
+    pub val: rapier::Real
 }
 
-/// Compnent that stores the mass of the multibody that a rigid body is part of
+/// Component that stores the mass of the multibody that a rigid body is part of
 /// Will be same as Mass of the body is not part of a multibody
 #[derive(Component)]
 pub struct MultibodyMass {
-    pub val: f32
+    pub val: rapier::Real
 }
 
 /// System for adding multi body mass to rigid bodies. If the body is not part of a multibody the mass will be equal
@@ -35,7 +35,7 @@ pub(crate) fn update_multibody_mass_system(
 /// 
 /// TODO: This could be improved since we will calculate the multibody mass for all the bodies in the multibody,
 /// but it is not crucial since it is a one timer. Could be when scaling up the amount of bodies
-fn mass_of_attached(handle: &rapier::RigidBodyHandle, multibody_set: &rapier::MultibodyJointSet, bodies: &rapier::RigidBodySet, parent_handle: Option<&rapier::RigidBodyHandle>) -> f32 {
+fn mass_of_attached(handle: &rapier::RigidBodyHandle, multibody_set: &rapier::MultibodyJointSet, bodies: &rapier::RigidBodySet, parent_handle: Option<&rapier::RigidBodyHandle>) -> f64 {
 
     let body = bodies.get(*handle).unwrap();
     let mut mass = body.mass();

--- a/crates/kesko_physics/src/mass.rs
+++ b/crates/kesko_physics/src/mass.rs
@@ -35,7 +35,7 @@ pub(crate) fn update_multibody_mass_system(
 /// 
 /// TODO: This could be improved since we will calculate the multibody mass for all the bodies in the multibody,
 /// but it is not crucial since it is a one timer. Could be when scaling up the amount of bodies
-fn mass_of_attached(handle: &rapier::RigidBodyHandle, multibody_set: &rapier::MultibodyJointSet, bodies: &rapier::RigidBodySet, parent_handle: Option<&rapier::RigidBodyHandle>) -> f64 {
+fn mass_of_attached(handle: &rapier::RigidBodyHandle, multibody_set: &rapier::MultibodyJointSet, bodies: &rapier::RigidBodySet, parent_handle: Option<&rapier::RigidBodyHandle>) -> rapier::Real {
 
     let body = bodies.get(*handle).unwrap();
     let mut mass = body.mass();

--- a/crates/kesko_physics/src/multibody.rs
+++ b/crates/kesko_physics/src/multibody.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use bevy::prelude::*;
 use bevy::utils::hashbrown::HashMap;
-use rapier3d::prelude as rapier;
+use crate::rapier_extern::rapier::prelude as rapier;
 use serde::{
     Serialize, Deserialize
 };

--- a/crates/kesko_physics/src/rapier_extern.rs
+++ b/crates/kesko_physics/src/rapier_extern.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "f64")]
+pub use rapier3d_f64 as rapier;
+#[cfg(feature = "f32")]
+pub use rapier3d as rapier;

--- a/crates/kesko_physics/src/rigid_body.rs
+++ b/crates/kesko_physics/src/rigid_body.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use rapier3d::prelude as rapier;
+use crate::rapier_extern::rapier::prelude as rapier;
 use fnv::FnvHashMap;
 
 use crate::{
@@ -77,7 +77,7 @@ pub(crate) fn add_rigid_bodies(
 mod tests {
 
     use bevy::prelude::*;
-    use rapier3d::prelude as rapier;
+    use crate::rapier_extern::rapier::prelude as rapier;
     use crate::rigid_body::{add_rigid_bodies, Entity2BodyHandle, RigidBody, RigidBodyHandle, BodyHandle2Entity};
     use crate::conversions::IntoBevy;
 
@@ -91,7 +91,7 @@ mod tests {
 
         world.init_resource::<Entity2BodyHandle>();
         world.init_resource::<BodyHandle2Entity>();
-        world.init_resource::<rapier3d::prelude::RigidBodySet>();
+        world.init_resource::<rapier::RigidBodySet>();
 
 
         let entity = world

--- a/crates/kesko_ui/src/multibody_component.rs
+++ b/crates/kesko_ui/src/multibody_component.rs
@@ -14,6 +14,7 @@ use kesko_physics::{
         JointMotorEvent,
         MotorCommand, revolute::RevoluteJoint, prismatic::PrismaticJoint, spherical::SphericalJoint, KeskoAxis
     },
+    rapier_extern::rapier::prelude as rapier
 };
 
 use kesko_core::interaction::multibody_selection::MultibodySelectionEvent;
@@ -25,12 +26,12 @@ use kesko_models::ControlDescription;
 struct JointData {
     name: String,
     joint_type: JointType,
-    val_axis_1: f32,
-    val_axis_2: f32,
-    val_axis_3: f32,
-    current_val_x: f32,
-    current_val_y: f32,
-    current_val_z: f32,
+    val_axis_1: rapier::Real,
+    val_axis_2: rapier::Real,
+    val_axis_3: rapier::Real,
+    current_val_x: rapier::Real,
+    current_val_y: rapier::Real,
+    current_val_z: rapier::Real,
     limits: Option<Vec2>
 }
 
@@ -338,30 +339,30 @@ impl MultibodyUIComponent {
     }
 
     /// Create a slider range from limits
-    fn get_slider_range(limits: Option<Vec2>, joint_type: &JointType) -> RangeInclusive<f32> {
+    fn get_slider_range(limits: Option<Vec2>, joint_type: &JointType) -> RangeInclusive<rapier::Real> {
 
         match joint_type {
             &JointType::Revolute => {
                 match limits {
-                    Some(limits) => RangeInclusive::<f32>::new(limits.x.to_degrees(), limits.y.to_degrees()),
-                    None => RangeInclusive::<f32>::new(-180.0, 180.0)
+                    Some(limits) => RangeInclusive::<rapier::Real>::new(limits.x.to_degrees() as rapier::Real, limits.y.to_degrees() as rapier::Real),
+                    None => RangeInclusive::<rapier::Real>::new(-180.0, 180.0)
                 }
             },
             &JointType::Prismatic => {
                 match limits {
-                    Some(limits) => RangeInclusive::<f32>::new(limits.x, limits.y),
-                    None => RangeInclusive::<f32>::new(-1.0, 1.0)
+                    Some(limits) => RangeInclusive::<rapier::Real>::new(limits.x as rapier::Real, limits.y as rapier::Real),
+                    None => RangeInclusive::<rapier::Real>::new(-1.0, 1.0)
                 }
             }
             _ => {
-                RangeInclusive::<f32>::new(-180.0, 180.0)
+                RangeInclusive::<rapier::Real>::new(-180.0, 180.0)
             }
         }
     }
 
     /// to smoothen the displayed joint values since they can often be -0.0/0.0 which
     /// result in a very erratic UI behavior
-    fn smooth_joint_val(val: f32) -> f32 {
+    fn smooth_joint_val(val: rapier::Real) -> rapier::Real {
         if val.abs() < 1e-2 && val.is_sign_negative(){
             return 0.0
         }


### PR DESCRIPTION
in order to switch between f32 and f64 for rapier the physic crate now reflect the same feature. the cut is not super clear. some conversion are needed in other creates and maybe more creates should have this feature.

by default f64 is enabled.

closes: #125 