### PR TITLE
change erp for the physics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ codegen-units = 1
 
 [dependencies]
 bevy = { version = "0.8.1" }
-kesko_physics = { version = "0.1.0", path = "crates/kesko_physics", features = ["f64"]}
+kesko_physics = { version = "0.1.0", path = "crates/kesko_physics", features = ["f32"]}
 kesko_core = { version = "0.1.0", path = "crates/kesko_core" }
 kesko_object_interaction = { version = "0.1.0", path = "crates/kesko_object_interaction"}
 kesko_raycast = { version = "0.1.0", path = "crates/kesko_raycast"}

--- a/crates/kesko_models/src/humanoid.rs
+++ b/crates/kesko_models/src/humanoid.rs
@@ -105,6 +105,7 @@ impl Humanoid {
                 .with_limits(Vec2::new(-FRAC_PI_4, FRAC_PI_4))
         )
         .insert_bundle(InteractiveBundle::<GroupDynamic>::default())
+        .insert(Mass {val: MASS})
         .insert(RigidBodyName("neck_x".to_owned()))
         .id();
 
@@ -126,6 +127,7 @@ impl Humanoid {
                 .with_limits(Vec2::new(-FRAC_PI_2, FRAC_PI_2))
         )
         .insert_bundle(InteractiveBundle::<GroupDynamic>::default())
+        .insert(Mass {val: MASS})
         .insert(RigidBodyName("neck_y".to_owned()))
         .id();
         

--- a/crates/kesko_physics/Cargo.toml
+++ b/crates/kesko_physics/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["f64"]
 f64 = ["dep:rapier3d-f64"]
 f32 = ["dep:rapier3d"]
 

--- a/crates/kesko_physics/src/collider.rs
+++ b/crates/kesko_physics/src/collider.rs
@@ -74,12 +74,11 @@ pub(crate) fn add_colliders(
         Entity, 
         &ColliderShape, 
         &RigidBodyHandle, 
-        Option<&Mass>,
         Option<&ColliderPhysicalProperties>, 
         Option<&GenerateCollisionEvents>), 
         Without<ColliderHandle>>
 ) {
-    for (entity, collider_shape, rigid_body_handle, mass, physical_props, gen_events) in query.iter() {
+    for (entity, collider_shape, rigid_body_handle, physical_props, gen_events) in query.iter() {
 
         let mut collider_builder = match collider_shape {
             ColliderShape::Cuboid {x_half, y_half, z_half} => {
@@ -101,10 +100,6 @@ pub(crate) fn add_colliders(
                 rapier::ColliderBuilder::cylinder(length / 2.0, *radius)
             }
         };
-
-        if let Some(mass) = mass {
-            collider_builder = collider_builder.mass(mass.val);
-        }
  
         if let Some(physical_props) = physical_props {
             collider_builder = collider_builder

--- a/crates/kesko_physics/src/lib.rs
+++ b/crates/kesko_physics/src/lib.rs
@@ -77,7 +77,9 @@ impl Plugin for PhysicsPlugin {
             .init_resource::<rapier::RigidBodySet>()            // Holds all the rigid bodies
             .init_resource::<rapier::ColliderSet>()             // Holds all the colliders
             .insert_resource(rapier::IntegrationParameters {            // sets the parameters that controls the simulation
-                erp: 0.99,
+                // setting this above 0.8 can cause instabilities, 
+                // if needed f64 feature should be used
+                erp: 0.8,
                 ..default()
             })   
             .init_resource::<rapier::IslandManager>()           // Keeps track of which dynamic rigid bodies that are moving and which are not

--- a/crates/kesko_physics/src/rigid_body.rs
+++ b/crates/kesko_physics/src/rigid_body.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
-use crate::rapier_extern::rapier::prelude as rapier;
+use crate::{
+    rapier_extern::rapier::prelude as rapier, 
+    mass::Mass
+};
 use fnv::FnvHashMap;
 
 use crate::{
@@ -39,11 +42,12 @@ pub(crate) fn add_rigid_bodies(
         Entity, 
         &RigidBody, 
         &Transform, 
+        Option<&Mass>,
         Option<&GravityScale>, 
         Option<&CanSleep>), 
         Without<RigidBodyHandle>>
 ) {
-    for (entity, rigid_body_comp, transform, gravity_scale, can_sleep) in query.iter() {
+    for (entity, rigid_body_comp, transform, mass, gravity_scale, can_sleep) in query.iter() {
 
         let mut rigid_body_builder = match rigid_body_comp {
             RigidBody::Fixed => rapier::RigidBodyBuilder::fixed(),
@@ -56,6 +60,9 @@ pub(crate) fn add_rigid_bodies(
 
         if let Some(can_sleep) = can_sleep {
             rigid_body_builder = rigid_body_builder.can_sleep(can_sleep.0);
+        }
+        if let Some(mass) = mass {
+            rigid_body_builder = rigid_body_builder.additional_mass(mass.val);
         }
 
         let rigid_body = rigid_body_builder


### PR DESCRIPTION
the high constraint violation setting of 0.99 for contact penetration caused instabilities when using f32. setting it to 0.8 seems to fix this.

also setting mass for colliders seemed to cause a strange behavior when it came to gravity for multibodies. instead setting additional mass for the rigidbody made gravity behave as expected.