### PR TITLE
use entity id in the name for a multibody

### DIFF
--- a/crates/kesko_physics/src/lib.rs
+++ b/crates/kesko_physics/src/lib.rs
@@ -102,9 +102,6 @@ impl Plugin for PhysicsPlugin {
             .add_event::<event::PhysicResponseEvent>()
             .add_system(event::handle_events)
 
-            // Multibody name registry, making sure all multibodies have unique names
-            .insert_resource(multibody::MultibodyNameRegistry::new())
-
             .add_event::<joint::JointMotorEvent>()
 
             .add_stage_after(CoreStage::First, PhysicsStage, Schedule::default())


### PR DESCRIPTION
remove the old name registry for multibodies and use the entity id of the root in the name instead.

closes: #131 