### PR TITLE
add angular velocity and velocity for joints

### DIFF
--- a/crates/kesko_physics/src/joint/prismatic.rs
+++ b/crates/kesko_physics/src/joint/prismatic.rs
@@ -16,7 +16,8 @@ pub struct PrismaticJoint {
     pub damping: rapier::Real,
     pub max_motor_force: rapier::Real,
 
-    position: rapier::Real
+    position: rapier::Real,
+    velocity: rapier::Real
 }
 
 impl PrismaticJoint {
@@ -31,7 +32,8 @@ impl PrismaticJoint {
             stiffness: 0.0,
             max_motor_force: rapier::Real::MAX,
 
-            position: 0.0
+            position: 0.0,
+            velocity: 0.0
         }
     }
 
@@ -66,7 +68,10 @@ impl PrismaticJoint {
         self
     }
 
-    pub fn update_position(&mut self, translation: Vec3) {
+    pub fn update_position_vel(&mut self, translation: Vec3, dt: rapier::Real) {
+
+        let prev_pos = self.position;
+
         match self.axis {
             KeskoAxis::X => self.position = translation.x as rapier::Real,
             KeskoAxis::NegX => self.position = -translation.x as rapier::Real,
@@ -76,6 +81,8 @@ impl PrismaticJoint {
             KeskoAxis::NegZ => self.position = -translation.z as rapier::Real,
             _ => error!("Prismatic joint does not have a valid axis")
         }
+
+        self.velocity = (self.position - prev_pos) / dt;
     }
 
     pub fn position(&self) -> rapier::Real {
@@ -83,7 +90,11 @@ impl PrismaticJoint {
     }
 
     pub fn state(&self) -> JointState {
-        JointState::Prismatic { axis: self.axis, position: self.position }
+        JointState::Prismatic { 
+            axis: self.axis, 
+            position: self.position,
+            velocity: self.velocity
+        }
     }
 }
 

--- a/crates/kesko_physics/src/joint/revolute.rs
+++ b/crates/kesko_physics/src/joint/revolute.rs
@@ -17,7 +17,8 @@ pub struct RevoluteJoint {
     pub stiffness: rapier::Real,
     pub max_motor_force: rapier::Real,
 
-    rotation: rapier::Real
+    rotation: rapier::Real,
+    angvel: rapier::Real
 }
 
 impl RevoluteJoint {
@@ -31,7 +32,8 @@ impl RevoluteJoint {
             damping: 0.0,
             stiffness: 0.0,
             max_motor_force: rapier::Real::MAX,
-            rotation: 0.0
+            rotation: 0.0,
+            angvel: 0.0
         }
     }
 
@@ -66,7 +68,8 @@ impl RevoluteJoint {
         self
     }
 
-    pub fn update_rotation(&mut self, rot: Quat) {
+    pub fn update_rotation_angvel(&mut self, rot: Quat, dt: rapier::Real) {
+        let prev_rot = self.rotation;
         // convert to local orientation by multiplying by the inverse of anchor's rotation
         let rotation = (self.parent_anchor.rotation.inverse() * self.child_anchor.rotation.inverse() * rot).to_euler(EulerRot::XYZ);
         match self.axis {
@@ -78,6 +81,8 @@ impl RevoluteJoint {
             KeskoAxis::NegZ => self.rotation = -rotation.2 as rapier::Real,
             _ => error!("Revolute joint does not have a valid axis")
         }
+
+        self.angvel = (self.rotation - prev_rot) / dt;
     }
 
     pub fn rotation(&self) -> rapier::Real {
@@ -87,7 +92,8 @@ impl RevoluteJoint {
     pub fn state(&self) -> JointState {
         JointState::Revolute {
             axis: self.axis,
-            angle: self.rotation
+            angle: self.rotation,
+            angular_velocity: self.angvel
         }
     }
 }

--- a/python/kesko/protocol/response.py
+++ b/python/kesko/protocol/response.py
@@ -30,6 +30,7 @@ class JointState(BaseModel):
     type: str
     axis: str
     angle: float
+    angular_velocity: float
 
 
 class MultibodyStates(BaseModel):

--- a/python/test.py
+++ b/python/test.py
@@ -3,7 +3,7 @@ import gym
 
 if __name__ == "__main__":
 
-    env = gym.make("kesko:kesko/Spider-v0", max_steps=1000)
+    env = gym.make("kesko:kesko/Spider-v0", max_steps=1000, render_mode="human")
     env.reset()
     for i in range(1_000):
         observation, reward, done, info = env.step(action=env.action_space.sample())


### PR DESCRIPTION
add velocities for prismastic and revolute joints. the joints are currently responsible for calculating the velocities using their previous postion/rotation

closes: #85 