### PR TITLE
add joint info in python api

### DIFF
--- a/crates/kesko_physics/src/event.rs
+++ b/crates/kesko_physics/src/event.rs
@@ -15,7 +15,8 @@ use crate::{
         Entity2BodyHandle, 
         RigidBodyHandle
     },
-    multibody::MultibodyRoot
+    multibody::MultibodyRoot,
+    joint::JointInfo
 };
 
 
@@ -34,9 +35,10 @@ pub enum PhysicResponseEvent {
     DespawnedBody(u64),
     DespawnedAllBodies,
     MultibodySpawned {
-        id: Entity,
+        id: u64,
+        entity: Entity,
         name: String,
-        links: BTreeMap<String, Entity>
+        joints: BTreeMap<u64, JointInfo>
     },
     RigidBodySpawned {
         id: Entity,

--- a/crates/kesko_physics/src/event/spawn.rs
+++ b/crates/kesko_physics/src/event/spawn.rs
@@ -1,25 +1,64 @@
+use std::collections::BTreeMap;
+
 use bevy::prelude::*;
 
 use crate::{
     event::PhysicResponseEvent,
     multibody::MultibodyRoot, 
-    rigid_body::RigidBody
+    rigid_body::RigidBody,
+    joint::{
+        revolute::RevoluteJoint,
+        prismatic::PrismaticJoint, JointInfo
+    }
 };
 
 
 pub(crate) fn send_spawned_events(
     mut event_writer: EventWriter<PhysicResponseEvent>,
-    bodies: Query<(Entity, &Name, Option<&MultibodyRoot>), Added<RigidBody>>
+    bodies: Query<(Entity, &Name, Option<&MultibodyRoot>), Added<RigidBody>>,
+    revolute_joints: Query<&RevoluteJoint>,
+    prismatic_joints: Query<&PrismaticJoint>,
 ) {
 
     for (entity, name, root) in bodies.iter() {
-        debug!("Sending spawn event"); 
         if let Some(root) = root {
 
+            // create a map with joint info
+            let joint_info_map = root.child_map.iter().map(|(name, e)| {
+
+                let joint_info = if let Ok(joint) = revolute_joints.get(*e) {
+                    Some(JointInfo::Revolute { 
+                        name: name.clone(), 
+                        axis: joint.axis, 
+                        limits: joint.limits, 
+                        damping: joint.damping, 
+                        stiffness: joint.stiffness, 
+                        max_motor_force: joint.max_motor_force
+                    })
+                } else if let Ok(joint) = prismatic_joints.get(*e) {
+                    Some(JointInfo::Prismatic { 
+                        name: name.clone(), 
+                        axis: joint.axis, 
+                        limits: joint.limits, 
+                        damping: joint.damping, 
+                        stiffness: joint.stiffness, 
+                        max_motor_force: joint.max_motor_force
+                    })
+                } else {
+                    None
+                };
+
+                (e.to_bits(), joint_info)
+            })
+            .filter(|(_, ji)| {ji.is_some()})
+            .map(|(id, ji)| {(id, ji.unwrap())})
+            .collect::<BTreeMap<u64, JointInfo>>();
+
             event_writer.send(PhysicResponseEvent::MultibodySpawned{ 
-                id: entity,
+                id: entity.to_bits(),
+                entity: entity,
                 name: root.name.clone(),
-                links: root.child_map.clone()
+                joints: joint_info_map
             });
         } else {
             event_writer.send(PhysicResponseEvent::RigidBodySpawned{ 

--- a/crates/kesko_physics/src/joint.rs
+++ b/crates/kesko_physics/src/joint.rs
@@ -18,7 +18,6 @@ use self::revolute::RevoluteJoint;
 pub type Entity2JointHandle = FnvHashMap<Entity, rapier::MultibodyJointHandle>;
 
 
-
 /// trait for converting an axis into a unit vector
 pub(crate) trait AxisIntoVec {
     fn into_unitvec(self) -> rapier::UnitVector<rapier::Real>;
@@ -61,6 +60,29 @@ pub enum KeskoAxis {
     AngX,
     AngY,
     AngZ
+}
+
+/// used to send joint info outside Kesko
+/// TODO: This is a bit redundant when spherical joints is not available
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase", tag = "type")]
+pub enum JointInfo {
+    Revolute { 
+        name: String,
+        axis: KeskoAxis,
+        limits: Option<Vec2>,
+        damping: rapier::Real,
+        stiffness: rapier::Real,
+        max_motor_force: rapier::Real
+    },
+    Prismatic {
+        name: String,
+        axis: KeskoAxis,
+        limits: Option<Vec2>,
+        damping: rapier::Real,
+        stiffness: rapier::Real,
+        max_motor_force: rapier::Real
+    }
 }
 
 /// used to send joint state outside Kesko

--- a/crates/kesko_physics/src/joint/revolute.rs
+++ b/crates/kesko_physics/src/joint/revolute.rs
@@ -1,8 +1,7 @@
 use bevy::prelude::*;
+
 use crate::rapier_extern::rapier::prelude as rapier;
-
 use crate::conversions::IntoRapier;
-
 use super::{AxisIntoVec, KeskoAxis, JointState};
 
 

--- a/python/kesko/envs/spider.py
+++ b/python/kesko/envs/spider.py
@@ -16,6 +16,7 @@ from ..protocol.commands import (
 from ..protocol.response import KeskoResponse, MultibodyStates
 from ..color import Color
 from ..model import KeskoModel
+from ..utils import action_space_from_limits
 
 
 class SpiderEnv(gym.Env):
@@ -39,6 +40,7 @@ class SpiderEnv(gym.Env):
 
         self._kesko = Kesko()
         self._kesko.initialize(mode=KeskoMode.RENDER if self.render_mode == "human" else KeskoMode.HEADLESS)
+        self._setup()
 
     def _setup(self):
 
@@ -70,16 +72,8 @@ class SpiderEnv(gym.Env):
         # start physics
         self._kesko.send(RunPhysics)
 
-        # TODO: Send the limits from Kesko
-        low = -np.pi / 6.0
-        high = np.pi / 6.0
-
         # Define spaces
-        dim_actions_space = len(self.spider_body.links)
-        self.action_space = gym.spaces.Box(
-            low=low * np.ones((dim_actions_space,)),
-            high=high * np.zeros((dim_actions_space,)),
-        )
+        self.action_space = action_space_from_limits([joint.limits for joint in self.spider_body.joints.values()])
         self.observation_space = gym.spaces.Space(tensor_state.shape)
 
         return tensor_state

--- a/python/kesko/kesko.py
+++ b/python/kesko/kesko.py
@@ -78,9 +78,9 @@ class Kesko:
                 if isinstance(action.values, (np.ndarray, torch.Tensor)):
                     # convert tensor or array to dict
                     action.values = {
-                        joint_name: val
-                        for joint_name, val in zip(
-                            self.bodies[action.name].links, action.values.tolist()
+                        joint.name: val
+                        for joint, val in zip(
+                            self.bodies[action.name].joints.values(), action.values.tolist()
                         )
                     }
             elif isinstance(action, DespawnAll) or action == DespawnAll:

--- a/python/kesko/protocol/response.py
+++ b/python/kesko/protocol/response.py
@@ -15,22 +15,32 @@ class CollisionStopped(BaseModel):
     flag: dict[str, int]
 
 
-class MultibodySpawned(BaseModel):
-    id: int
+class JointInfo(BaseModel):
     name: str
-    links: dict[str, int]
-
-
-class RigidBodySpawned(BaseModel):
-    id: int
-    name: str
-
+    type: str
+    axis: str
+    limits: list
+    damping: float
+    stiffness: float
+    max_motor_force: float
+    
 
 class JointState(BaseModel):
     type: str
     axis: str
     angle: float
     angular_velocity: float
+
+
+class MultibodySpawned(BaseModel):
+    id: int
+    name: str
+    joints: dict[int, JointInfo]
+
+
+class RigidBodySpawned(BaseModel):
+    id: int
+    name: str
 
 
 class MultibodyStates(BaseModel):

--- a/python/kesko/utils.py
+++ b/python/kesko/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+import gym
 
 
 def to_tensor(arr: np.ndarray):
@@ -8,3 +9,20 @@ def to_tensor(arr: np.ndarray):
 
 def to_numpy(t: torch.Tensor):
     return t.numpy()
+
+
+def action_space_from_limits(limits: list, normalized: bool = True):
+    """Creates an action space from a list of limits"""
+    highs = []
+    lows = []
+    for limit in limits:
+        low_limit, high_limit = limit
+
+        if normalized:
+            high_limit = high_limit / abs(high_limit) if high_limit != 0.0 else 0.0
+            low_limit = low_limit / abs(low_limit) if low_limit != 0.0 else 0.0
+        
+        highs.append(high_limit)
+        lows.append(low_limit)
+
+    return gym.spaces.Box(low=np.array(lows), high=np.array(highs))


### PR DESCRIPTION
Info about the joints in a multibody is now sent when a new multibody is spawned. All info that is passed can be seen in the JointInfo struct.

Also create the gym action space from the limits in the passed joint info for the spider env.

closes #157 