### PR TITLE
[pykesko] tcp backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ Cargo.lock
 
 # python
 **/__pycache__/**
-/venv
+**/venv
 
 # vscode
 .idea

--- a/kesko/crates/kesko_models/src/lib.rs
+++ b/kesko/crates/kesko_models/src/lib.rs
@@ -8,7 +8,7 @@ pub mod spider;
 pub mod wheely;
 
 use bevy::prelude::*;
-use pyo3::pyclass;
+use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
 pub struct ModelPlugin;
@@ -47,8 +47,10 @@ pub enum Model {
     Plane,
 }
 
+#[pymethods]
 impl Model {
     /// Names to use for example in UI
+    #[getter]
     pub const fn name(&self) -> &'static str {
         match self {
             Self::Car => "Car",

--- a/kesko/src/lib.rs
+++ b/kesko/src/lib.rs
@@ -19,3 +19,7 @@ pub mod physics {
 pub mod diagnostic {
     pub use kesko_diagnostic::*;
 }
+
+pub mod tcp {
+    pub use kesko_tcp::*;
+}

--- a/pykesko/pykesko/__init__.py
+++ b/pykesko/pykesko/__init__.py
@@ -1,7 +1,8 @@
 from pykesko.kesko import Kesko
 
 # import the the rust bindings
-from .pykesko import KeskoApp, Model
+from .pykesko import KeskoApp as _KeskoApp
+from .pykesko import Model, run_kesko_tcp
 
 from gym.envs.registration import register
 

--- a/pykesko/pykesko/backend/backend.py
+++ b/pykesko/pykesko/backend/backend.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from typing import Protocol
+from typing import Protocol, Optional
 
 from ..protocol.response import KeskoResponse
 from ..protocol.commands import Command
@@ -22,5 +22,5 @@ class Backend(Protocol):
     def step(self, commands: list[Command]) -> KeskoResponse:
         ...
 
-    def close(self):
+    def close(self) -> Optional[KeskoResponse]:
         ...

--- a/pykesko/pykesko/backend/bindings.py
+++ b/pykesko/pykesko/backend/bindings.py
@@ -18,7 +18,7 @@ from ..protocol.response import (
     MultibodyStates,
     MultibodySpawned,
 )
-from ..pykesko import KeskoApp, Model
+from ..pykesko import KeskoApp
 
 
 class BindingBackend:

--- a/pykesko/pykesko/kesko.py
+++ b/pykesko/pykesko/kesko.py
@@ -32,6 +32,7 @@ class Kesko:
         self.backend.initialize(self.render_mode)
 
     def send(self, commands: Union[list[Command], Command]) -> KeskoResponse:
+
         if not isinstance(commands, list):
             commands = [commands]
         commands = self._prepare_commands(commands)


### PR DESCRIPTION
change tcp backend to launch kesko with tcp using bindings instead of a separate binary.

this removes the problem of having to ship multiple binaries with pykesko.