### PR TITLE
set iyes-loopless version to 0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Kesko is pre-release and in its infancy, quite far from useful (but perhaps a bi
 
 <!-- GETTING STARTED -->
 ## Getting Started
-Kesko in not yet available on [crates.io](https://crates.io/) but you can clone the repo and build it locally.
+Kesko in not yet available on [crates.io](https://crates.io/) but you can clone the repo and run locally.
 ### Prerequisites
  
  Make sure you have [Rust](https://www.rust-lang.org/learn/get-started) installed.
@@ -63,6 +63,7 @@ Kesko in not yet available on [crates.io](https://crates.io/) but you can clone 
    ```
 2. Build and run the demo example
    ```bash
+   cd kesko/kesko
    cargo run --bin kesko_demo --release
    ```
 

--- a/kesko/crates/kesko_physics/Cargo.toml
+++ b/kesko/crates/kesko_physics/Cargo.toml
@@ -9,7 +9,7 @@ f32 = ["dep:rapier3d"]
 
 [dependencies]
 bevy = { workspace = true }
-iyes_loopless = { git = "https://github.com/IyesGames/iyes_loopless.git", branch = "main"}
+iyes_loopless = "0.8"
 rapier3d-f64 = { git = "https://github.com/wynss/rapier.git", optional = true, features = ["serde-serialize"]}
 rapier3d = { git = "https://github.com/wynss/rapier.git", optional = true, features = ["serde-serialize"] }
 nalgebra = "0.31.0"

--- a/kesko/crates/kesko_tcp/Cargo.toml
+++ b/kesko/crates/kesko_tcp/Cargo.toml
@@ -8,7 +8,7 @@ bevy = { workspace = true }
 serde = "1.0.137"
 serde_json = "1.0.81"
 serde_traitobject = "0.2.7"
-iyes_loopless = { git = "https://github.com/IyesGames/iyes_loopless.git", branch = "main"}
+iyes_loopless = "0.8"
 
 kesko_core = { path = "../kesko_core" }
 kesko_physics = { path = "../kesko_physics" }


### PR DESCRIPTION
before Kesko is migrated to bevy 0.9 iyes loopless version needs to be 0.8

also fixed a small mistake in the README