### PR TITLE
fix tcp systems

### DIFF
--- a/kesko/crates/kesko_core/src/lib.rs
+++ b/kesko/crates/kesko_core/src/lib.rs
@@ -28,6 +28,9 @@ use bevy::{
     DefaultPlugins,
 };
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash, SystemSet)]
+pub struct HandleEventsSet;
+
 pub struct CorePlugin {
     pub log_level: Level,
 }
@@ -82,13 +85,14 @@ impl Plugin for CorePlugin {
             // simulator system events
             .add_event::<event::SimulatorRequestEvent>()
             .add_event::<event::SimulatorResponseEvent>()
+            .configure_set(Last, HandleEventsSet)
             .add_systems(
                 Last,
                 (
                     event::handle_system_events,
                     event::handle_serializable_state_request,
                     event::handle_motor_command_requests,
-                ),
+                ).in_set(HandleEventsSet),
             );
     }
 }

--- a/kesko/crates/kesko_tcp/src/lib.rs
+++ b/kesko/crates/kesko_tcp/src/lib.rs
@@ -6,6 +6,7 @@ use std::net::TcpListener;
 use bevy::prelude::*;
 
 use kesko_types::resource::KeskoRes;
+use kesko_core::HandleEventsSet;
 
 const URL: &str = "127.0.0.1:8080";
 
@@ -42,7 +43,7 @@ impl Plugin for TcpPlugin {
                     .insert_resource(KeskoRes(listener))
                     .insert_resource(KeskoRes(TcpBuffer::new()))
                     .configure_set(First, TcpSet::Request)
-                    .configure_set(Last, TcpSet::Response)
+                    .configure_set(Last, TcpSet::Response.after(HandleEventsSet))
                     .add_systems(
                         First,
                         (handle_incoming_connections, apply_deferred)


### PR DESCRIPTION
tcp systems was not scheduled to run after the event updated. Introducing a set for the events systems that is scheduled to run before the tcp response system.